### PR TITLE
Support loading packages over https

### DIFF
--- a/src/components/RunButton.js
+++ b/src/components/RunButton.js
@@ -37,7 +37,7 @@ export default function RunButton(props) {
     let isObject = true;
     const outPackage = await runSUSHI(props.text);
     let jsonOutput = JSON.stringify(outPackage, replacer, 2);
-    if (outPackage.codeSystems) {
+    if (outPackage && outPackage.codeSystems) {
       if (
         !outPackage.codeSystems.length &&
         !outPackage.extensions.length &&

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -30,7 +30,9 @@ export default function ButtonAppBar() {
         <Typography className={classes.title} variant="h6">
           FSH Online
         </Typography>
-        <Button className={classes.docButton}>Documentation</Button>
+        <Button className={classes.docButton} href="https://fshschool.org/" target="_blank">
+          Documentation
+        </Button>
       </Toolbar>
     </AppBar>
   );

--- a/src/tests/utils/Load.test.js
+++ b/src/tests/utils/Load.test.js
@@ -23,9 +23,9 @@ describe('#unzipDependencies', () => {
   });
   it('should make an http request and extract data from the resulting zip folder', () => {
     unzipDependencies(resources);
-    const callbackFunct = getSpy.mock.calls[0][1];
+    const callbackFunction = getSpy.mock.calls[0][1];
     expect(getSpy).toBeCalled();
-    expect(getSpy).toBeCalledWith('http://packages.fhir.org/hl7.fhir.r4.core/4.0.1', callbackFunct);
+    expect(getSpy).toBeCalledWith('https://packages.fhir.org/hl7.fhir.r4.core/4.0.1', callbackFunction);
   });
 });
 

--- a/src/utils/Load.js
+++ b/src/utils/Load.js
@@ -4,7 +4,7 @@ import http from 'http';
 
 export function unzipDependencies(resources) {
   return new Promise((resolve) => {
-    http.get('http://packages.fhir.org/hl7.fhir.r4.core/4.0.1', function (res) {
+    http.get('https://packages.fhir.org/hl7.fhir.r4.core/4.0.1', function (res) {
       const extract = tarStream.extract();
       // Unzip files
       extract.on('entry', function (header, stream, next) {


### PR DESCRIPTION
This PR makes the call to fetch FHIR packages over https. To test this locally, I ran `HTTPS=true npm start`. When loading the packages (when you click the "Run" button), master will give you a `Mixed Content` error and this branch should properly load the packages. For more info on running it locally using HTTPS and for the script for windows, I used [this documentation](https://create-react-app.dev/docs/using-https-in-development/).

I also added the FSHSchool link to the documentation button since it didn't go anywhere previously.