### PR TITLE
FSH Syntax Highlighting

### DIFF
--- a/src/components/CodeMirrorComponent.js
+++ b/src/components/CodeMirrorComponent.js
@@ -1,12 +1,61 @@
 import React from 'react';
 import { Box } from '@material-ui/core';
-import { UnControlled as CodeMirror } from 'react-codemirror2';
+import { UnControlled as ReactCodeMirror } from 'react-codemirror2';
 import { makeStyles } from '@material-ui/core/styles';
+import CodeMirror from 'codemirror';
 import '../style/CodeMirrorComponent.css';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
+require('codemirror/addon/mode/simple');
 require('codemirror/mode/xml/xml');
 require('codemirror/mode/javascript/javascript');
+
+// Define FSH syntax highlighting
+// Regular expressions from https://github.com/standardhealth/vscode-language-fsh/blob/master/syntaxes/fsh.tmLanguage.json
+CodeMirror.defineSimpleMode('fsh', {
+  start: [
+    // The regex matches the token, the token property contains the type
+    {
+      regex: /"(?:[^\\]|\\.)*?(?:"|$)/,
+      token: 'atom'
+    },
+    {
+      regex: /\b(Alias|CodeSystem|Expression|Extension|Description|Id|Instance|InstanceOf|Invariant|Mapping|Mixins|Parent|Profile|RuleSet|Severity|Source|Target|Title|Usage|ValueSet|XPath)(?=\s*:)\b/,
+      token: 'keyword'
+    },
+    {
+      // NOTE: Original regex has (?<=\s) at start and (?=\s) at the end. However, there are known shortcomings with look ahead/look behind with the simple mode approach
+      regex: /\b(and|codes|contains|exclude|from|includes|is-a|is-not-a|named|obeys|only|or|system|units|valueset|where|D|MS|N|SU|TU|\\?!)\b/,
+      token: 'def'
+    },
+    {
+      regex: /(\(\s*)(exactly|example|extensible|preferred|required)(\s*\))/,
+      token: 'def'
+    },
+    {
+      regex: /\*|->|=|:/,
+      token: 'def'
+    },
+    {
+      regex: /\b(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*))\b/,
+      token: 'atom'
+    },
+    {
+      regex: /\b(true|false)\b/,
+      token: 'string'
+    },
+    {
+      regex: /#[^\s]*/,
+      token: 'string'
+    },
+    { regex: /\/\/.*/, token: 'comment' },
+    { regex: /\/\*/, token: 'comment', next: 'comment' }
+  ],
+  comment: [
+    { regex: /.*?\*\//, token: 'comment', next: 'start' },
+    { regex: /.*/, token: 'comment' }
+  ]
+});
 
 const useStyles = makeStyles((theme) => ({
   box: {
@@ -21,12 +70,14 @@ export default function CodeMirrorComponent(props) {
   function updateText(text) {
     props.updateTextValue(text);
   }
+
   return (
     <Box className={classes.box}>
-      <CodeMirror
+      <ReactCodeMirror
         className="react-codemirror2"
         value={'Edit FSH here!'}
         options={{
+          mode: 'fsh',
           theme: 'material',
           lineNumbers: true
         }}


### PR DESCRIPTION
This uses CodeMirror's [simple mode](https://codemirror.net/demo/simplemode.html) for defining a new language syntax highlighting. This mode uses regular expressions, similar to how our current VS Code extension works. Because of that, most of the regular expressions match the regular expressions in the VS Code extension. The tokens are used to categorize each regular expression and give them a specific color. I tried to match the colors based on the default color theme in VS Code. Pictures of a comparison are below.

The one difference between the regular expressions here and in the VS Code extension is the lack of look ahead and look behind. The simple mode approach for defining a language in Code Mirror can't support these. The purpose of the look behind/ahead is so that keywords that are not surrounded by spaces do not get highlighted. Without them, something like `code.coding.system` will highlight "system" in FSH Online but not in the VS Code extension. When implementing this, I decided it was easier to continue using the simple mode approach since it so closely mirrored the VS Code extension and this was only one small difference. If reviewers don't like the difference or if it becomes bothersome to users in the future, we can explore other ways to support the look behind.

VS Code:
![image](https://user-images.githubusercontent.com/30803904/92111338-28a7b180-edba-11ea-9b58-19cedf70d3d5.png)

FSH Online:
![image](https://user-images.githubusercontent.com/30803904/92111638-99e76480-edba-11ea-9287-8f585e434f91.png)
