### PR TITLE
SUSHI Output updates

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ let consoleMessages = [];
 let errorMessages = [];
 console.log = function getMessages(message) {
   consoleMessages.push(message);
-  if (message.startsWith('error')) {
+  if (message && message.startsWith('error')) {
     errorMessages.push(message);
   }
 };
@@ -47,6 +47,7 @@ export default function App() {
     setOutputText(sushiOutput);
     setIsOutputObject(isObject);
   }
+
   function updateInputTextValue(text) {
     setInputText(text);
   }

--- a/src/App.js
+++ b/src/App.js
@@ -21,11 +21,11 @@ const useStyles = makeStyles((theme) => ({
 
 const log = console.log; //eslint-disable-line no-unused-vars
 let consoleMessages = [];
-let errorMessages = [];
+let errorAndWarningMessages = [];
 console.log = function getMessages(message) {
   consoleMessages.push(message);
-  if (message && message.startsWith('error')) {
-    errorMessages.push(message);
+  if (message && (message.startsWith('error') || message.startsWith('warn'))) {
+    errorAndWarningMessages.push(message);
   }
 };
 
@@ -39,7 +39,7 @@ export default function App() {
 
   function resetLogMessages() {
     consoleMessages = [];
-    errorMessages = [];
+    errorAndWarningMessages = [];
   }
 
   function handleRunButton(doRunSUSHI, sushiOutput, isObject) {
@@ -61,7 +61,12 @@ export default function App() {
           <CodeMirrorComponent value={inputText} updateTextValue={updateInputTextValue} />
         </Grid>
         <Grid className={classes.itemTop} item xs={6}>
-          <JSONOutput displaySUSHI={doRunSUSHI} text={outputText} isObject={isOutputObject} errors={errorMessages} />
+          <JSONOutput
+            displaySUSHI={doRunSUSHI}
+            text={outputText}
+            isObject={isOutputObject}
+            errorsAndWarnings={errorAndWarningMessages}
+          />
         </Grid>
         <Grid className={classes.itemBottom} item xs={12}>
           <ConsoleComponent consoleMessages={consoleMessages} />

--- a/src/App.js
+++ b/src/App.js
@@ -20,9 +20,13 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const log = console.log; //eslint-disable-line no-unused-vars
-let msgArray = [];
+let consoleMessages = [];
+let errorMessages = [];
 console.log = function getMessages(message) {
-  msgArray.push(message);
+  consoleMessages.push(message);
+  if (message.startsWith('error')) {
+    errorMessages.push(message);
+  }
 };
 
 export default function App() {
@@ -34,7 +38,8 @@ export default function App() {
   const [isOutputObject, setIsOutputObject] = useState(false);
 
   function resetLogMessages() {
-    msgArray = [];
+    consoleMessages = [];
+    errorMessages = [];
   }
 
   function handleRunButton(doRunSUSHI, sushiOutput, isObject) {
@@ -55,10 +60,10 @@ export default function App() {
           <CodeMirrorComponent value={inputText} updateTextValue={updateInputTextValue} />
         </Grid>
         <Grid className={classes.itemTop} item xs={6}>
-          <JSONOutput displaySUSHI={doRunSUSHI} text={outputText} isObject={isOutputObject} />
+          <JSONOutput displaySUSHI={doRunSUSHI} text={outputText} isObject={isOutputObject} errors={errorMessages} />
         </Grid>
         <Grid className={classes.itemBottom} item xs={12}>
-          <ConsoleComponent msgArray={msgArray} />
+          <ConsoleComponent consoleMessages={consoleMessages} />
         </Grid>
       </Grid>
     </div>

--- a/src/components/ConsoleComponent.js
+++ b/src/components/ConsoleComponent.js
@@ -7,8 +7,7 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(2),
     color: theme.palette.common.white,
     background: theme.palette.common.black,
-    height: '200%',
-    fontFamily: 'Consolas'
+    height: '200%'
   },
   pre: {
     margin: '0px'

--- a/src/components/ConsoleComponent.js
+++ b/src/components/ConsoleComponent.js
@@ -21,10 +21,10 @@ export default function Console(props) {
   return (
     <Box className={classes.box} overflow="scroll">
       <h3>Console</h3>
-      {props.msgArray.map((msg, i) => {
+      {props.consoleMessages.map((message, i) => {
         return (
           <pre key={i} className={classes.pre}>
-            {msg}
+            {message}
           </pre>
         );
       })}

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -9,7 +9,6 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.primary,
     background: theme.palette.grey[400],
     height: '100%',
-    fontFamily: 'Consolas',
     noWrap: false
   }
 }));

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -14,37 +14,45 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-export default function JSONOutput(props) {
-  const classes = useStyles();
-  let display = '';
-
-  //Checks to insure the doRunSUSHI is true (aka button has been pressed) and there is text to display for the output
-  if (props.displaySUSHI && props.text) {
-    if (props.isObject) {
-      display = JSON.parse(props.text);
-      return (
-        <Box className={classes.box} border={1} overflow="scroll">
-          <h4>Your Output: </h4>
-          <ReactJson src={display} displayDataTypes={false} collapsed={4} name={false} />
-        </Box>
-      );
-    } else {
-      return (
-        <Box className={classes.box} border={1} overflow="scroll">
-          <h4>Your Output: </h4>
-          {props.errors.length > 0 ? (
-            props.errors.map((error, i) => <pre key={i}>{error}</pre>)
-          ) : (
-            <pre>{props.text}</pre>
-          )}
-        </Box>
-      );
-    }
-  } else {
+const renderErrorMessage = (errors = []) => {
+  if (errors.length > 0) {
     return (
-      <Box className={classes.box} border={1}>
-        <h4>Your JSON Output Will Display Here: </h4>
-      </Box>
+      <span>
+        <h4>Errors</h4>
+        {errors.map((error, i) => (
+          <pre key={i}>{error}</pre>
+        ))}
+      </span>
     );
   }
+  return;
+};
+
+const renderDisplayContent = (displaySUSHI, text, isObject) => {
+  if (displaySUSHI && text && isObject) {
+    const packageJSON = JSON.parse(text);
+    return (
+      <span>
+        <h4>Results</h4>
+        <ReactJson src={packageJSON} displayDataTypes={false} collapsed={3} name={false} />
+      </span>
+    );
+  } else if (displaySUSHI && text) {
+    return <pre>{text}</pre>;
+  }
+  return '';
+};
+
+export default function JSONOutput(props) {
+  const classes = useStyles();
+  const errorContent = renderErrorMessage(props.errors);
+  const displayContent = renderDisplayContent(props.displaySUSHI, props.text, props.isObject);
+
+  return (
+    <Box className={classes.box} border={1} overflow="scroll">
+      <h3>SUSHI Output</h3>
+      {errorContent}
+      {displayContent}
+    </Box>
+  );
 }

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -13,13 +13,13 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-const renderErrorMessage = (errors = []) => {
-  if (errors.length > 0) {
+const renderErrorAndWarningContent = (errorsAndWarnings = []) => {
+  if (errorsAndWarnings.length > 0) {
     return (
       <span>
-        <h4>Errors</h4>
-        {errors.map((error, i) => (
-          <pre key={i}>{error}</pre>
+        <h4>Errors and Warnings</h4>
+        {errorsAndWarnings.map((message, i) => (
+          <pre key={i}>{message}</pre>
         ))}
       </span>
     );
@@ -44,13 +44,13 @@ const renderDisplayContent = (displaySUSHI, text, isObject) => {
 
 export default function JSONOutput(props) {
   const classes = useStyles();
-  const errorContent = renderErrorMessage(props.errors);
+  const errorAndWarningContent = renderErrorAndWarningContent(props.errorsAndWarnings);
   const displayContent = renderDisplayContent(props.displaySUSHI, props.text, props.isObject);
 
   return (
     <Box className={classes.box} border={1} overflow="scroll">
       <h3>SUSHI Output</h3>
-      {errorContent}
+      {errorAndWarningContent}
       {displayContent}
     </Box>
   );

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -25,7 +25,7 @@ export default function JSONOutput(props) {
       return (
         <Box className={classes.box} border={1} overflow="scroll">
           <h4>Your Output: </h4>
-          <ReactJson src={display} displayDataTypes={false} collapsed={1} name={false} />
+          <ReactJson src={display} displayDataTypes={false} collapsed={4} name={false} />
         </Box>
       );
     } else {

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -34,7 +34,7 @@ const renderDisplayContent = (displaySUSHI, text, isObject) => {
     return (
       <span>
         <h4>Results</h4>
-        <ReactJson src={packageJSON} displayDataTypes={false} collapsed={3} name={false} />
+        <ReactJson src={packageJSON} displayDataTypes={false} collapsed={false} name={false} />
       </span>
     );
   } else if (displaySUSHI && text) {

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -32,7 +32,11 @@ export default function JSONOutput(props) {
       return (
         <Box className={classes.box} border={1} overflow="scroll">
           <h4>Your Output: </h4>
-          <pre>{props.text}</pre>
+          {props.errors.length > 0 ? (
+            props.errors.map((error, i) => <pre key={i}>{error}</pre>)
+          ) : (
+            <pre>{props.text}</pre>
+          )}
         </Box>
       );
     }

--- a/src/components/RunButton.js
+++ b/src/components/RunButton.js
@@ -46,11 +46,11 @@ export default function RunButton(props) {
         !outPackage.valueSets.length
       ) {
         isObject = false;
-        jsonOutput = 'Your FSH is invalid. Just keep swimming!';
+        jsonOutput = '';
       }
     } else {
       isObject = false;
-      jsonOutput = 'Your FSH is invalid. Just keep swimming!';
+      jsonOutput = '';
     }
 
     props.onClick(true, jsonOutput, isObject);

--- a/src/components/RunButton.js
+++ b/src/components/RunButton.js
@@ -16,7 +16,9 @@ const useStyles = makeStyles((theme) => ({
   },
   button: {
     color: theme.palette.common.white,
-    background: theme.palette.success.dark
+    background: theme.palette.success.dark,
+    textTransform: 'none',
+    fontWeight: 'bold'
   }
 }));
 

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -13,16 +13,17 @@ const useStyles = makeStyles((theme) => ({
   docButton: {
     margin: theme.spacing(1),
     color: 'white',
-    background: 'linear-gradient(45deg, #30638E 30%, #285a85 90%)',
-    boxShadow: '0 3px 5px 2px #285a85'
+    textTransform: 'none',
+    fontWeight: 'bold'
   },
   title: {
     flexGrow: 1,
-    edge: 'start'
+    edge: 'start',
+    fontWeight: 'bold'
   }
 }));
 
-export default function ButtonAppBar() {
+export default function TopBar() {
   const classes = useStyles();
   return (
     <AppBar className={classes.root}>

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,8 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+pre,
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-size: 13px;
 }

--- a/src/tests/components/ConsoleComponent.test.js
+++ b/src/tests/components/ConsoleComponent.test.js
@@ -16,16 +16,16 @@ afterEach(() => {
 });
 
 it('Renders with the appropriate label', () => {
-  const { getByText } = render(<ConsoleComponent msgArray={[]} />, container);
+  const { getByText } = render(<ConsoleComponent consoleMessages={[]} />, container);
   const textElement = getByText(/Console/i);
 
   expect(textElement).toBeInTheDocument();
 });
 
 it('Renders with proper messages in the console', () => {
-  const msgArray = ['Hello', 'Goodbye', 'How are you?'];
+  const consoleMessages = ['Hello', 'Goodbye', 'How are you?'];
 
-  const { getByText, queryByText } = render(<ConsoleComponent msgArray={msgArray} />, container);
+  const { getByText, queryByText } = render(<ConsoleComponent consoleMessages={consoleMessages} />, container);
   const textElement1 = getByText(/Hello/i);
   const textElement2 = getByText(/Goodbye/i);
   const textElement3 = getByText(/How are you\?/i);

--- a/src/tests/components/JSONOutput.test.js
+++ b/src/tests/components/JSONOutput.test.js
@@ -22,15 +22,31 @@ it('Renders with the proper heading as default', () => {
   expect(textElement).toBeInTheDocument();
 });
 it('Renders with the proper heading and updates with proper text', () => {
-  const { getByText } = render(<JSONOutput displaySUSHI={true} text={'Hello World'} />, container);
+  const { getByText } = render(<JSONOutput displaySUSHI={true} text={'Hello World'} errors={[]} />, container);
   const textElement = getByText(/Your Output:/i);
 
   expect(textElement).toBeInTheDocument();
 });
 
-it('Renders with the default heading if doRunSUSHI is false', () => {
-  const { getByText } = render(<JSONOutput displaySUSHI={false} text={'Hello World'} />, container);
+it('Renders with the default heading if displaySUSHI is false', () => {
+  const { getByText } = render(<JSONOutput displaySUSHI={false} text={'Hello World'} errors={[]} />, container);
   const textElement = getByText(/Your JSON Output Will Display Here:/i);
 
   expect(textElement).toBeInTheDocument();
+});
+
+it('Renders error messages if present', () => {
+  const { getByText } = render(
+    <JSONOutput
+      displaySUSHI={true}
+      text={'Hello World'}
+      errors={['error Unexpected input', 'error Something else wrong']}
+    />,
+    container
+  );
+  const firstError = getByText(/Unexpected input/);
+  const secondError = getByText(/Something else wrong/);
+
+  expect(firstError).toBeInTheDocument();
+  expect(secondError).toBeInTheDocument();
 });

--- a/src/tests/components/JSONOutput.test.js
+++ b/src/tests/components/JSONOutput.test.js
@@ -15,38 +15,62 @@ afterEach(() => {
   container = null;
 });
 
-it('Renders with the proper heading as default', () => {
-  const { getByText } = render(<JSONOutput />, container);
-  const textElement = getByText(/Your JSON Output Will Display Here:/i);
-
-  expect(textElement).toBeInTheDocument();
-});
-it('Renders with the proper heading and updates with proper text', () => {
-  const { getByText } = render(<JSONOutput displaySUSHI={true} text={'Hello World'} errors={[]} />, container);
-  const textElement = getByText(/Your Output:/i);
-
-  expect(textElement).toBeInTheDocument();
-});
-
 it('Renders with the default heading if displaySUSHI is false', () => {
-  const { getByText } = render(<JSONOutput displaySUSHI={false} text={'Hello World'} errors={[]} />, container);
-  const textElement = getByText(/Your JSON Output Will Display Here:/i);
+  // Initial case, nothing from SUSHI is displayed
+  const { getByText, queryByText } = render(
+    <JSONOutput displaySUSHI={false} text={'Hello World'} errors={[]} />,
+    container
+  );
+  const headerElement = getByText(/SUSHI Output/i);
+  const resultsElement = queryByText(/Results/i);
+  const errorsElement = queryByText(/Errors/i);
 
-  expect(textElement).toBeInTheDocument();
+  expect(headerElement).toBeInTheDocument();
+  expect(resultsElement).not.toBeInTheDocument();
+  expect(errorsElement).not.toBeInTheDocument();
+});
+
+it('Renders with the proper heading and updates with proper text when not an object', () => {
+  const { getByText, queryByText } = render(
+    <JSONOutput displaySUSHI={true} text={'Hello World'} isObject={false} errors={[]} />,
+    container
+  );
+  const resultsElement = queryByText(/Results/i);
+  const errorsElement = queryByText(/Errors/i);
+  const textElement = getByText(/Hello World/i);
+
+  expect(resultsElement).not.toBeInTheDocument();
+  expect(errorsElement).not.toBeInTheDocument();
+  expect(textElement).toBeInTheDocument(); // Mimics the 'loading...' case
+});
+
+it('Renders with the proper headings when text is an object (SUSHI Package)', () => {
+  const { getByText, queryByText } = render(
+    <JSONOutput displaySUSHI={true} text={JSON.stringify({ profiles: [] })} isObject={true} errors={[]} />,
+    container
+  );
+  const resultsElement = getByText(/Results/i);
+  const errorsElement = queryByText(/Errors/i);
+
+  expect(resultsElement).toBeInTheDocument(); // isObject is true so results are printed
+  expect(errorsElement).not.toBeInTheDocument(); // No errors
 });
 
 it('Renders error messages if present', () => {
   const { getByText } = render(
     <JSONOutput
       displaySUSHI={true}
+      isObject={false}
       text={'Hello World'}
       errors={['error Unexpected input', 'error Something else wrong']}
     />,
     container
   );
+  const errorHeading = getByText(/Errors/);
   const firstError = getByText(/Unexpected input/);
   const secondError = getByText(/Something else wrong/);
 
+  expect(errorHeading).toBeInTheDocument();
   expect(firstError).toBeInTheDocument();
   expect(secondError).toBeInTheDocument();
 });

--- a/src/tests/components/JSONOutput.test.js
+++ b/src/tests/components/JSONOutput.test.js
@@ -18,7 +18,7 @@ afterEach(() => {
 it('Renders with the default heading if displaySUSHI is false', () => {
   // Initial case, nothing from SUSHI is displayed
   const { getByText, queryByText } = render(
-    <JSONOutput displaySUSHI={false} text={'Hello World'} errors={[]} />,
+    <JSONOutput displaySUSHI={false} text={'Hello World'} errorsAndWarnings={[]} />,
     container
   );
   const headerElement = getByText(/SUSHI Output/i);
@@ -32,7 +32,7 @@ it('Renders with the default heading if displaySUSHI is false', () => {
 
 it('Renders with the proper heading and updates with proper text when not an object', () => {
   const { getByText, queryByText } = render(
-    <JSONOutput displaySUSHI={true} text={'Hello World'} isObject={false} errors={[]} />,
+    <JSONOutput displaySUSHI={true} text={'Hello World'} isObject={false} errorsAndWarnings={[]} />,
     container
   );
   const resultsElement = queryByText(/Results/i);
@@ -46,7 +46,7 @@ it('Renders with the proper heading and updates with proper text when not an obj
 
 it('Renders with the proper headings when text is an object (SUSHI Package)', () => {
   const { getByText, queryByText } = render(
-    <JSONOutput displaySUSHI={true} text={JSON.stringify({ profiles: [] })} isObject={true} errors={[]} />,
+    <JSONOutput displaySUSHI={true} text={JSON.stringify({ profiles: [] })} isObject={true} errorsAndWarnings={[]} />,
     container
   );
   const resultsElement = getByText(/Results/i);
@@ -62,7 +62,7 @@ it('Renders error messages if present', () => {
       displaySUSHI={true}
       isObject={false}
       text={'Hello World'}
-      errors={['error Unexpected input', 'error Something else wrong']}
+      errorsAndWarnings={['error Unexpected input', 'error Something else wrong']}
     />,
     container
   );

--- a/src/tests/components/RunButton.test.js
+++ b/src/tests/components/RunButton.test.js
@@ -46,7 +46,7 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits a bad p
     expect(runSUSHISpy).toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledTimes(2);
     expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false);
-    expect(onClick).toHaveBeenCalledWith(true, 'Your FSH is invalid. Just keep swimming!', false);
+    expect(onClick).toHaveBeenCalledWith(true, '', false);
   });
 });
 
@@ -68,7 +68,7 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits an empt
     expect(runSUSHISpy).toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledTimes(2);
     expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false);
-    expect(onClick).toHaveBeenCalledWith(true, 'Your FSH is invalid. Just keep swimming!', false);
+    expect(onClick).toHaveBeenCalledWith(true, '', false);
   });
 });
 

--- a/src/utils/RunSUSHI.js
+++ b/src/utils/RunSUSHI.js
@@ -50,6 +50,10 @@ export async function runSUSHI(input) {
   startingErrors = errors;
   startingWarns = warns;
 
+  // Remove snapshots
+  outPackage.profiles = outPackage.profiles.map((p) => p.toJSON(false));
+  outPackage.extensions = outPackage.extensions.map((e) => e.toJSON(false));
+
   return outPackage;
 }
 


### PR DESCRIPTION
This PR includes small changes requested to FSH Online to get it to alpha capabilities. These changes include:

- Including the list of errors at the top of the right hand side pane. Just the error messages are displayed but the full output can still be found in the console at the bottom of the page.
- Removing the snapshot from the StructureDefinitions in the package we get back from SUSHI
- Opening all fields in the JSON output by default. Now that the snapshot is not on the profiles and extensions, opening all the fields by default seems much more manageable and seems to be preferable.

Update: e66703c also updates the fonts used on the site. I just tried to align the style a bit more with FSH School, but the fonts are still slightly off, but I thought they were at least closer. If anyone is better with fonts than I am and is more bothered by the changes in this commit than master, I can revert it.