### PR TITLE
User Provided Configuration

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import TopBar from './components/TopBar';
 import JSONOutput from './components/JSONOutput';
 import ConsoleComponent from './components/ConsoleComponent';
 import CodeMirrorComponent from './components/CodeMirrorComponent';
-import RunButton from './components/RunButton';
+import SUSHIControls from './components/SUSHIControls';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -42,7 +42,7 @@ export default function App() {
     errorAndWarningMessages = [];
   }
 
-  function handleRunButton(doRunSUSHI, sushiOutput, isObject) {
+  function handleSUSHIControls(doRunSUSHI, sushiOutput, isObject) {
     setDoRunSUSHI(doRunSUSHI);
     setOutputText(sushiOutput);
     setIsOutputObject(isObject);
@@ -55,7 +55,7 @@ export default function App() {
   return (
     <div className="root">
       <TopBar />
-      <RunButton onClick={handleRunButton} text={inputText} resetLogMessages={resetLogMessages} />
+      <SUSHIControls onClick={handleSUSHIControls} text={inputText} resetLogMessages={resetLogMessages} />
       <Grid className={classes.container} container>
         <Grid className={classes.itemTop} item xs={6}>
           <CodeMirrorComponent value={inputText} updateTextValue={updateInputTextValue} />

--- a/src/components/RunButton.js
+++ b/src/components/RunButton.js
@@ -1,6 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Box, Button } from '@material-ui/core';
+import TextField from '@material-ui/core/TextField';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
 import { runSUSHI } from '../utils/RunSUSHI';
 import './CodeMirrorComponent';
 
@@ -19,6 +25,13 @@ const useStyles = makeStyles((theme) => ({
     background: theme.palette.success.dark,
     textTransform: 'none',
     fontWeight: 'bold'
+  },
+  secondaryButton: {
+    color: theme.palette.common.white,
+    background: '#30638E',
+    textTransform: 'none',
+    fontWeight: 'bold',
+    marginLeft: '5px'
   }
 }));
 
@@ -31,13 +44,35 @@ function replacer(key, value) {
 
 export default function RunButton(props) {
   const classes = useStyles();
+  const [open, setOpen] = useState(false);
+  const [canonical, setCanonical] = useState('http://example.org');
+  const [version, setVersion] = useState('1.0.0');
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const updateCanonical = (event) => {
+    const newCanonical = event.target.value;
+    setCanonical(newCanonical);
+  };
+
+  const updateVersion = (event) => {
+    const newVersion = event.target.value;
+    setVersion(newVersion);
+  };
 
   //Sets the doRunSUSHI to true
   async function handleClick() {
     props.resetLogMessages();
     props.onClick(true, 'Loading...', false);
     let isObject = true;
-    const outPackage = await runSUSHI(props.text);
+    const config = { canonical, version, FSHOnly: true, fhirVersion: ['4.0.1'] };
+    const outPackage = await runSUSHI(props.text, config);
     let jsonOutput = JSON.stringify(outPackage, replacer, 2);
     if (outPackage && outPackage.codeSystems) {
       if (
@@ -63,6 +98,45 @@ export default function RunButton(props) {
       <Button className={classes.button} onClick={handleClick} testid="Button">
         Run
       </Button>
+      <Button className={classes.secondaryButton} onClick={handleClickOpen}>
+        Configuration
+      </Button>
+      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+        <DialogTitle id="form-dialog-title">SUSHI Configuration Settings</DialogTitle>
+        <DialogContent>
+          <DialogContentText>Change the configuration options to use when running SUSHI on your FSH</DialogContentText>
+          <TextField
+            id="canonical"
+            margin="dense"
+            fullWidth
+            label="Canonical URL"
+            defaultValue="http://example.org"
+            onChange={updateCanonical}
+          />
+          <TextField
+            id="version"
+            margin="dense"
+            fullWidth
+            label="Version"
+            defaultValue="1.0.0"
+            onChange={updateVersion}
+          />
+          <TextField
+            id="dependencies"
+            disabled
+            margin="dense"
+            label="Dependencies"
+            helperText="(Not yet supported) dependencyA#id, dependencyB#id"
+            defaultValue="dependency#id"
+            fullWidth
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="primary">
+            Done
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -110,7 +110,7 @@ export default function SUSHIControls(props) {
             margin="dense"
             fullWidth
             label="Canonical URL"
-            defaultValue="http://example.org"
+            defaultValue={canonical}
             onChange={updateCanonical}
           />
           <TextField
@@ -118,7 +118,7 @@ export default function SUSHIControls(props) {
             margin="dense"
             fullWidth
             label="Version"
-            defaultValue="1.0.0"
+            defaultValue={version}
             onChange={updateVersion}
           />
           <TextField

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -42,13 +42,13 @@ function replacer(key, value) {
   return value;
 }
 
-export default function RunButton(props) {
+export default function SUSHIControls(props) {
   const classes = useStyles();
   const [open, setOpen] = useState(false);
   const [canonical, setCanonical] = useState('http://example.org');
   const [version, setVersion] = useState('1.0.0');
 
-  const handleClickOpen = () => {
+  const handleOpen = () => {
     setOpen(true);
   };
 
@@ -67,7 +67,7 @@ export default function RunButton(props) {
   };
 
   //Sets the doRunSUSHI to true
-  async function handleClick() {
+  async function handleRunClick() {
     props.resetLogMessages();
     props.onClick(true, 'Loading...', false);
     let isObject = true;
@@ -95,10 +95,10 @@ export default function RunButton(props) {
 
   return (
     <Box className={classes.box}>
-      <Button className={classes.button} onClick={handleClick} testid="Button">
+      <Button className={classes.button} onClick={handleRunClick} testid="Button">
         Run
       </Button>
-      <Button className={classes.secondaryButton} onClick={handleClickOpen}>
+      <Button className={classes.secondaryButton} onClick={handleOpen}>
         Configuration
       </Button>
       <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">

--- a/src/tests/components/SUSHIControls.test.js
+++ b/src/tests/components/SUSHIControls.test.js
@@ -3,7 +3,7 @@ import * as runSUSHI from '../../utils/RunSUSHI';
 import { act } from 'react-dom/test-utils';
 import { render, wait, fireEvent } from '@testing-library/react';
 import { unmountComponentAtNode } from 'react-dom';
-import RunButton from '../../components/RunButton';
+import SUSHIControls from '../../components/SUSHIControls';
 import 'fake-indexeddb/auto';
 
 const badSUSHIPackage = { a: '1', b: '2' };
@@ -34,7 +34,7 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits a bad p
   const runSUSHISpy = jest.spyOn(runSUSHI, 'runSUSHI').mockReset().mockResolvedValue(badSUSHIPackage);
 
   act(() => {
-    render(<RunButton onClick={onClick} resetLogMessages={resetLogMessages} />, container);
+    render(<SUSHIControls onClick={onClick} resetLogMessages={resetLogMessages} />, container);
   });
   const button = document.querySelector('[testid=Button]');
   act(() => {
@@ -56,7 +56,7 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits an empt
   const runSUSHISpy = jest.spyOn(runSUSHI, 'runSUSHI').mockReset().mockResolvedValue(emptySUSHIPackage);
 
   act(() => {
-    render(<RunButton onClick={onClick} resetLogMessages={resetLogMessages} />, container);
+    render(<SUSHIControls onClick={onClick} resetLogMessages={resetLogMessages} />, container);
   });
   const button = document.querySelector('[testid=Button]');
   act(() => {
@@ -78,7 +78,7 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits a good 
   const runSUSHISpy = jest.spyOn(runSUSHI, 'runSUSHI').mockReset().mockResolvedValue(goodSUSHIPackage);
 
   act(() => {
-    render(<RunButton onClick={onClick} resetLogMessages={resetLogMessages} />, container);
+    render(<SUSHIControls onClick={onClick} resetLogMessages={resetLogMessages} />, container);
   });
   const button = document.querySelector('[testid=Button]');
   act(() => {
@@ -100,7 +100,7 @@ it('uses user provided canonical when calling runSUSHI', () => {
   const runSUSHISpy = jest.spyOn(runSUSHI, 'runSUSHI').mockReset().mockResolvedValue(goodSUSHIPackage);
 
   const { getByText, getByLabelText } = render(
-    <RunButton onClick={onClick} resetLogMessages={resetLogMessages} />,
+    <SUSHIControls onClick={onClick} resetLogMessages={resetLogMessages} />,
     container
   );
 
@@ -129,7 +129,7 @@ it('uses user provided version when calling runSUSHI', () => {
   const runSUSHISpy = jest.spyOn(runSUSHI, 'runSUSHI').mockReset().mockResolvedValue(goodSUSHIPackage);
 
   const { getByText, getByLabelText } = render(
-    <RunButton onClick={onClick} resetLogMessages={resetLogMessages} />,
+    <SUSHIControls onClick={onClick} resetLogMessages={resetLogMessages} />,
     container
   );
 

--- a/src/tests/utils/RunSUSHI.test.js
+++ b/src/tests/utils/RunSUSHI.test.js
@@ -6,6 +6,12 @@ import 'fake-indexeddb/auto';
 import { fhirdefs } from 'fsh-sushi';
 
 const FHIRDefinitions = fhirdefs.FHIRDefinitions;
+const defaultConfig = {
+  canonical: 'http://example.org',
+  version: '1.0.0',
+  FSHOnly: true,
+  fhirVersion: ['4.0.1']
+};
 
 describe('#runSUSHI', () => {
   it('should return an undefined package when we get invalid FHIRDefinitions', async () => {
@@ -13,7 +19,7 @@ describe('#runSUSHI', () => {
     const loadDefsSpy = jest.spyOn(processing, 'loadExternalDependencies').mockReset().mockResolvedValue(FHIRDefs);
     const text =
       'Profile: FishPatient Parent: Patient Id: fish-patient Title: "Fish Patient" Description: "A patient that is a type of fish."';
-    const outPackage = await runSUSHI(text);
+    const outPackage = await runSUSHI(text, defaultConfig);
     expect(loadDefsSpy).toHaveBeenCalled();
     expect(outPackage).toBeUndefined();
   });
@@ -25,7 +31,7 @@ describe('#runSUSHI', () => {
     const loadSpy = jest.spyOn(processing, 'loadExternalDependencies').mockReset().mockResolvedValue(FHIRDefs);
     const text =
       'Profile: FishPatient\nParent: Patient\nId: fish-patient\nTitle: "Fish Patient"\n Description: "A patient that is a type of fish."';
-    const outPackage = await runSUSHI(text);
+    const outPackage = await runSUSHI(text, defaultConfig);
     expect(loadSpy).toHaveBeenCalled();
     expect(outPackage.profiles).toHaveLength(1);
   });
@@ -42,7 +48,7 @@ describe('#runSUSHI', () => {
         throw new Error('Failed to fill tank');
       });
     const input = 'Improper FSH code!';
-    const outPackage = await runSUSHI(input);
+    const outPackage = await runSUSHI(input, defaultConfig);
     expect(loadSpy).toHaveBeenCalled();
     expect(fillTankSpy).toHaveBeenCalled();
     expect(outPackage).toBeUndefined();

--- a/src/utils/RunSUSHI.js
+++ b/src/utils/RunSUSHI.js
@@ -18,10 +18,19 @@ const FHIRDefinitions = fhirdefs.FHIRDefinitions;
 let startingErrors = 0;
 let startingWarns = 0;
 
-export async function runSUSHI(input) {
-  // Hard Code config
-  const config = { canonical: 'http://default.org' };
-
+/**
+ * Load dependencies (FHIR R4) and run SUSHI on provided text
+ *
+ * @param {string} input - string containing FSH text
+ * @param {object} config - Configuration for SUSHI based on user input and defaults
+ * config.canonical: user set, defaults to http://example.org
+ * config.version: user set, defaults to 1.0.0
+ * config.FSHOnly: true
+ * config.fhirVersion: [4.0.1]
+ *
+ * @returns Package with FHIR resources
+ */
+export async function runSUSHI(input, config) {
   // Load dependencies
   let defs = new FHIRDefinitions();
   const version = 1;


### PR DESCRIPTION
This PR supports basic user controls for SUSHI configuration. I believe the only SUSHI config options that should be applicable to the playground are `canonical`, `version`, and `dependencies`. This PR allows a user to specify the `canonical` and `version` and the field will be used by SUSHI when the "Run" button is clicked. Since we don't yet support loading any other dependencies besides R4, I added a disabled field for those, although it can be removed or commented out if that is easier. Also, if there is any feedback on the format/location of these controls, they can always be changed. The dialog box was my initial idea and it looked alright, but I'm no designer.

There is a warning in the console that gets logged by the Material UI Dialog component. I believe it is just a warning due to the fact that we are using React Strict Mode, and I found a [GitHub Issue](https://github.com/mui-org/material-ui/issues/13394) where Material UI seems to be tracking support for Strict Mode in the next major version, so I think it is okay to leave this as is. The warning does not get logged in the production build that will end up on fshschool.org.

Also, all I did was rename the RunButton.js -> SUSHIControls.js. I'm not sure why GitHub seems so thrown off by the rename + additions. f0cb64f has all the functional changes and 3a5d73d does the renaming if that's easier to look at.