### PR TITLE
Enable dependencies

### DIFF
--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import { Box, Button } from '@material-ui/core';
+import { makeStyles, createMuiTheme } from '@material-ui/core/styles';
+import { Box, Button, ThemeProvider } from '@material-ui/core';
 import TextField from '@material-ui/core/TextField';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -41,6 +41,12 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
+const theme = createMuiTheme({
+  typography: {
+    fontFamily: 'Open Sans'
+  }
+});
+
 function replacer(key, value) {
   if (key === 'config') {
     return undefined;
@@ -48,16 +54,16 @@ function replacer(key, value) {
   return value;
 }
 
-export async function sliceDependency(dependencies) {
+export function sliceDependency(dependencies) {
   let returnArr = [];
   const arr = dependencies.split(',');
   for (let i = 0; i < arr.length; i++) {
+    arr[i] = arr[i].trim();
     if (arr[i] === '') {
       continue;
     }
-    arr[i] = arr[i].trim();
     let singleDep = arr[i].split('#');
-    returnArr[i] = [singleDep[0], singleDep[1]];
+    returnArr.push([singleDep[0], singleDep[1]]);
   }
   return returnArr;
 }
@@ -97,7 +103,7 @@ export default function SUSHIControls(props) {
     props.resetLogMessages();
     props.onClick(true, 'Loading...', false);
     let isObject = true;
-    const dependencyArr = await sliceDependency(dependencies);
+    const dependencyArr = sliceDependency(dependencies);
     const config = { canonical, version, FSHOnly: true, fhirVersion: ['4.0.1'] };
     const outPackage = await runSUSHI(props.text, config, dependencyArr);
     let jsonOutput = JSON.stringify(outPackage, replacer, 2);
@@ -121,49 +127,53 @@ export default function SUSHIControls(props) {
   }
 
   return (
-    <Box className={classes.box}>
-      <Button className={classes.button} onClick={handleRunClick} testid="Button">
-        Run
-      </Button>
-      <Button className={classes.secondaryButton} onClick={handleOpen}>
-        Configuration
-      </Button>
-      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
-        <DialogTitle id="form-dialog-title">SUSHI Configuration Settings</DialogTitle>
-        <DialogContent>
-          <DialogContentText>Change the configuration options to use when running SUSHI on your FSH</DialogContentText>
-          <TextField
-            id="canonical"
-            margin="dense"
-            fullWidth
-            label="Canonical URL"
-            defaultValue={canonical}
-            onChange={updateCanonical}
-          />
-          <TextField
-            id="version"
-            margin="dense"
-            fullWidth
-            label="Version"
-            defaultValue={version}
-            onChange={updateVersion}
-          />
-          <TextField
-            id="dependencies"
-            margin="dense"
-            fullWidth
-            label="Dependencies"
-            helperText="dependencyA#id, dependencyB#id"
-            defaultValue={dependencies}
-            onChange={updateDependencyString}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Done
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </Box>
+    <ThemeProvider theme={theme}>
+      <Box className={classes.box}>
+        <Button className={classes.button} onClick={handleRunClick} testid="Button">
+          Run
+        </Button>
+        <Button className={classes.secondaryButton} onClick={handleOpen}>
+          Configuration
+        </Button>
+        <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+          <DialogTitle id="form-dialog-title">SUSHI Configuration Settings</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              Change the configuration options to use when running SUSHI on your FSH
+            </DialogContentText>
+            <TextField
+              id="canonical"
+              margin="dense"
+              fullWidth
+              label="Canonical URL"
+              defaultValue={canonical}
+              onChange={updateCanonical}
+            />
+            <TextField
+              id="version"
+              margin="dense"
+              fullWidth
+              label="Version"
+              defaultValue={version}
+              onChange={updateVersion}
+            />
+            <TextField
+              id="dependencies"
+              margin="dense"
+              fullWidth
+              label="Dependencies"
+              helperText="dependencyA#id, dependencyB#id"
+              defaultValue={dependencies}
+              onChange={updateDependencyString}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleClose} color="primary">
+              Done
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Box>
+    </ThemeProvider>
   );
 }

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -49,15 +49,17 @@ function replacer(key, value) {
 }
 
 async function sliceDependency(dependencies) {
-  const arr = dependencies.split(',');
   let returnArr = [];
-  let i;
-  for (i = 0; i < arr.length; i++) {
+  const arr = dependencies.split(',');
+  for (let i = 0; i < arr.length; i++) {
     if (arr[i][0] === ' ') {
       arr[i] = arr[i].slice(1);
     }
     let singleDep = arr[i].split('#');
     returnArr[i] = [singleDep[0], singleDep[1]];
+  }
+  if (returnArr[0][0] === 'dependency') {
+    returnArr.shift();
   }
   return returnArr;
 }

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -48,7 +48,7 @@ function replacer(key, value) {
   return value;
 }
 
-async function sliceDependency(dependencies) {
+export async function sliceDependency(dependencies) {
   let returnArr = [];
   const arr = dependencies.split(',');
   for (let i = 0; i < arr.length; i++) {

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -52,14 +52,12 @@ async function sliceDependency(dependencies) {
   let returnArr = [];
   const arr = dependencies.split(',');
   for (let i = 0; i < arr.length; i++) {
-    if (arr[i][0] === ' ') {
-      arr[i] = arr[i].slice(1);
+    if (arr[i] === '') {
+      continue;
     }
+    arr[i] = arr[i].trim();
     let singleDep = arr[i].split('#');
     returnArr[i] = [singleDep[0], singleDep[1]];
-  }
-  if (returnArr[0][0] === 'dependency') {
-    returnArr.shift();
   }
   return returnArr;
 }
@@ -69,7 +67,7 @@ export default function SUSHIControls(props) {
   const [open, setOpen] = useState(false);
   const [canonical, setCanonical] = useState('http://example.org');
   const [version, setVersion] = useState('1.0.0');
-  const [dependencies, setDependencies] = useState('dependency#id');
+  const [dependencies, setDependencies] = useState('');
 
   const handleOpen = () => {
     setOpen(true);

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -128,7 +128,7 @@ export default function SUSHIControls(props) {
 
   return (
     <ThemeProvider theme={theme}>
-      <Box className={classes.box}>
+      <Box className={classes.box} borderLeft={1} borderRight={1}>
         <Button className={classes.button} onClick={handleRunClick} testid="Button">
           Run
         </Button>
@@ -162,7 +162,7 @@ export default function SUSHIControls(props) {
               margin="dense"
               fullWidth
               label="Dependencies"
-              helperText="dependencyA#id, dependencyB#id"
+              helperText="dependencyID#version, dependencyID#version"
               defaultValue={dependencies}
               onChange={updateDependencyString}
             />

--- a/src/tests/components/SUSHIControls.test.js
+++ b/src/tests/components/SUSHIControls.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as runSUSHI from '../../utils/RunSUSHI';
+import { sliceDependency } from '../../components/SUSHIControls';
 import { act } from 'react-dom/test-utils';
 import { render, wait, fireEvent } from '@testing-library/react';
 import { unmountComponentAtNode } from 'react-dom';
@@ -94,7 +95,7 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits a good 
   });
 });
 
-it('uses user provided canonical when calling runSUSHI', () => {
+it('uses user provided canonical when calling runSUSHI', async () => {
   const onClick = jest.fn();
   const resetLogMessages = jest.fn();
   const runSUSHISpy = jest.spyOn(runSUSHI, 'runSUSHI').mockReset().mockResolvedValue(goodSUSHIPackage);
@@ -111,8 +112,10 @@ it('uses user provided canonical when calling runSUSHI', () => {
 
   fireEvent.change(canonicalInput, { target: { value: 'http://other.org' } });
 
-  const runButton = getByText('Run');
-  fireEvent.click(runButton);
+  const button = document.querySelector('[testid=Button]');
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
 
   const expectedConfig = {
     canonical: 'http://other.org',
@@ -120,10 +123,12 @@ it('uses user provided canonical when calling runSUSHI', () => {
     FSHOnly: true,
     fhirVersion: ['4.0.1']
   };
-  expect(runSUSHISpy).toHaveBeenCalledWith(undefined, expectedConfig); // Includes new config
+  await wait(() => {
+    expect(runSUSHISpy).toHaveBeenCalledWith(undefined, expectedConfig, []); // Includes new config
+  });
 });
 
-it('uses user provided version when calling runSUSHI', () => {
+it('uses user provided version when calling runSUSHI', async () => {
   const onClick = jest.fn();
   const resetLogMessages = jest.fn();
   const runSUSHISpy = jest.spyOn(runSUSHI, 'runSUSHI').mockReset().mockResolvedValue(goodSUSHIPackage);
@@ -140,8 +145,10 @@ it('uses user provided version when calling runSUSHI', () => {
 
   fireEvent.change(canonicalInput, { target: { value: '2.0.0' } });
 
-  const runButton = getByText('Run');
-  fireEvent.click(runButton);
+  const button = document.querySelector('[testid=Button]');
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
 
   const expectedConfig = {
     canonical: 'http://example.org',
@@ -149,5 +156,59 @@ it('uses user provided version when calling runSUSHI', () => {
     FSHOnly: true,
     fhirVersion: ['4.0.1']
   };
-  expect(runSUSHISpy).toHaveBeenCalledWith(undefined, expectedConfig); // Includes new version
+
+  await wait(() => {
+    expect(runSUSHISpy).toHaveBeenCalledWith(undefined, expectedConfig, []); // Includes new version
+  });
+});
+
+it('uses user provided dependencies when calling runSUSHI', async () => {
+  const onClick = jest.fn();
+  const resetLogMessages = jest.fn();
+  const runSUSHISpy = jest.spyOn(runSUSHI, 'runSUSHI').mockReset().mockResolvedValue(goodSUSHIPackage);
+
+  const { getByText, getByLabelText } = render(
+    <SUSHIControls onClick={onClick} resetLogMessages={resetLogMessages} />,
+    container
+  );
+
+  const configButton = getByText('Configuration');
+  fireEvent.click(configButton);
+  const dependencyInput = getByLabelText('Dependencies');
+  expect(dependencyInput.value).toEqual(''); // Default
+
+  fireEvent.change(dependencyInput, { target: { value: 'hl7.fhir.us.core#3.1.1, hello#123' } });
+
+  const button = document.querySelector('[testid=Button]');
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
+  const defaultConfig = { FSHOnly: true, canonical: 'http://example.org', fhirVersion: ['4.0.1'], version: '1.0.0' };
+
+  const expectedDependencyArrr = [
+    ['hl7.fhir.us.core', '3.1.1'],
+    ['hello', '123']
+  ];
+
+  await wait(() => {
+    expect(runSUSHISpy).toHaveBeenCalledWith(undefined, defaultConfig, expectedDependencyArrr); // Includes new version
+  });
+});
+
+describe('#sliceDependency()', () => {
+  it('should correctly parse a given array of dependencies', async () => {
+    const input = 'hl7.fhir.us.core#3.1.1, testing#123';
+    const returnArr = await sliceDependency(input);
+    expect(returnArr).toEqual([
+      ['hl7.fhir.us.core', '3.1.1'],
+      ['testing', '123']
+    ]);
+  });
+
+  it('should correctly parse an empty array of dependencies', async () => {
+    const input = '';
+    const returnArr = await sliceDependency(input);
+    expect(returnArr).toEqual([]);
+  });
 });

--- a/src/tests/components/SUSHIControls.test.js
+++ b/src/tests/components/SUSHIControls.test.js
@@ -186,29 +186,29 @@ it('uses user provided dependencies when calling runSUSHI', async () => {
 
   const defaultConfig = { FSHOnly: true, canonical: 'http://example.org', fhirVersion: ['4.0.1'], version: '1.0.0' };
 
-  const expectedDependencyArrr = [
+  const expectedDependencyArr = [
     ['hl7.fhir.us.core', '3.1.1'],
     ['hello', '123']
   ];
 
   await wait(() => {
-    expect(runSUSHISpy).toHaveBeenCalledWith(undefined, defaultConfig, expectedDependencyArrr); // Includes new version
+    expect(runSUSHISpy).toHaveBeenCalledWith(undefined, defaultConfig, expectedDependencyArr); // Includes new version
   });
 });
 
 describe('#sliceDependency()', () => {
-  it('should correctly parse a given array of dependencies', async () => {
-    const input = 'hl7.fhir.us.core#3.1.1, testing#123';
-    const returnArr = await sliceDependency(input);
+  it('should correctly parse a given array of dependencies', () => {
+    const input = 'hl7.fhir.us.core#3.1.1, , testing#123';
+    const returnArr = sliceDependency(input);
     expect(returnArr).toEqual([
       ['hl7.fhir.us.core', '3.1.1'],
       ['testing', '123']
     ]);
   });
 
-  it('should correctly parse an empty array of dependencies', async () => {
+  it('should correctly parse an empty array of dependencies', () => {
     const input = '';
-    const returnArr = await sliceDependency(input);
+    const returnArr = sliceDependency(input);
     expect(returnArr).toEqual([]);
   });
 });

--- a/src/tests/utils/Load.test.js
+++ b/src/tests/utils/Load.test.js
@@ -24,7 +24,7 @@ describe('#unzipDependencies', () => {
     getSpy.mockClear();
   });
   it('should make an http request and extract data from the resulting zip folder', () => {
-    unzipDependencies(resources);
+    unzipDependencies(resources, 'hl7.fhir.r4.core', '4.0.1');
     const callbackFunction = getSpy.mock.calls[0][1];
     expect(getSpy).toBeCalled();
     expect(getSpy).toBeCalledWith('https://packages.fhir.org/hl7.fhir.r4.core/4.0.1', callbackFunction);
@@ -42,14 +42,14 @@ describe('#loadDependenciesInStorage', () => {
       const OpenDB = indexedDB.open('Test Database');
       OpenDB.onupgradeneeded = (event) => {
         database = event.target.result;
-        database.createObjectStore('resources', { keyPath: ['id', 'resourceType'] });
+        database.createObjectStore('testDependency1.0.0', { keyPath: ['id', 'resourceType'] });
       };
       OpenDB.onsuccess = async (event) => {
         database = event.target.result;
-        await loadDependenciesInStorage(database, resourcesTest);
+        await loadDependenciesInStorage(database, resourcesTest, 'testDependency', '1.0.0');
         const databaseValue = await database
-          .transaction(['resources'], 'readonly')
-          .objectStore('resources', { keyPath: ['id', 'resourceType'] })
+          .transaction(['testDependency1.0.0'], 'readonly')
+          .objectStore('testDependency1.0.0', { keyPath: ['id', 'resourceType'] })
           .getAll();
         databaseValue.onsuccess = () => {
           resolve(databaseValue.result);
@@ -77,12 +77,12 @@ describe('#loadAsFHIRDefs', () => {
       const OpenDB = indexedDB.open('Test Database');
       OpenDB.onupgradeneeded = (event) => {
         database = event.target.result;
-        database.createObjectStore('resources', { keyPath: ['id', 'resourceType'] });
+        database.createObjectStore('testDependency1.0.0', { keyPath: ['id', 'resourceType'] });
       };
       OpenDB.onsuccess = async (event) => {
         database = event.target.result;
-        await loadDependenciesInStorage(database, resourcesTest);
-        finalDefs = await loadAsFHIRDefs(FHIRdefs, database);
+        await loadDependenciesInStorage(database, resourcesTest, 'testDependency', '1.0.0');
+        finalDefs = await loadAsFHIRDefs(FHIRdefs, database, 'testDependency', '1.0.0');
         resolve(finalDefs);
       };
       OpenDB.onerror = () => {

--- a/src/tests/utils/Processing.test.js
+++ b/src/tests/utils/Processing.test.js
@@ -1,4 +1,4 @@
-import { loadExternalDependencies, fillTank } from '../../utils/Processing';
+import { loadExternalDependencies, fillTank, toUpgradeDatabase } from '../../utils/Processing';
 import { fhirdefs, sushiImport } from 'fsh-sushi';
 import * as loadModule from '../../utils/Load';
 import 'fake-indexeddb/auto';
@@ -6,11 +6,43 @@ import 'fake-indexeddb/auto';
 const FHIRDefinitions = fhirdefs.FHIRDefinitions;
 const RawFSH = sushiImport.RawFSH;
 
+describe('#toUpgradeDatabase()', () => {
+  it('should say we need to upgrade database if we have no ObjectStores or dependency inputs and should return proper version number', async () => {
+    const dependencyArr = [];
+    const toUpgradeDatabaseReturn = await toUpgradeDatabase(dependencyArr);
+    expect(toUpgradeDatabaseReturn.shouldUpdate).toEqual(true);
+    expect(toUpgradeDatabaseReturn.version).toEqual(1);
+  });
+
+  it('should not upgrade database if we have the correct objectStores needed for our dependency array', async () => {
+    let helperReturn = { shouldUpdate: false, version: 1 };
+    await new Promise((resolve, reject) => {
+      let database = null;
+      const OpenIDBRequest = indexedDB.open('Test Database');
+      OpenIDBRequest.onsuccess = function (event) {
+        database = event.target.result;
+        database.close();
+        resolve(helperReturn);
+      };
+      OpenIDBRequest.onupgradeneeded = function (event) {
+        database = event.target.result;
+        database.createObjectStore('testDependency1.0.0', { keyPath: ['id', 'resourceType'] });
+      };
+      OpenIDBRequest.onerror = function (event) {
+        reject(event);
+      };
+    });
+    const dependencyArr = [['testDependency', '1.0.0']];
+    let toUpgradeDatabaseReturn = await toUpgradeDatabase(dependencyArr, 'Test Database');
+    expect(toUpgradeDatabaseReturn.shouldUpdate).toEqual(false);
+  });
+});
+
 describe('#loadExternalDependencies()', () => {
   it('should log an error when it fails to make the database', () => {
     const defs = new FHIRDefinitions();
     const version = -1;
-    const dependencyDefs = loadExternalDependencies(defs, version);
+    const dependencyDefs = loadExternalDependencies(defs, version, []);
     return expect(dependencyDefs).rejects.toThrow(TypeError);
   });
 
@@ -26,7 +58,7 @@ describe('#loadExternalDependencies()', () => {
     const loadAsDefsSpy = jest.spyOn(loadModule, 'loadAsFHIRDefs').mockImplementation(() => {
       return undefined;
     });
-    const dependencyDefs = loadExternalDependencies(defs, version);
+    const dependencyDefs = loadExternalDependencies(defs, version, []);
     await dependencyDefs;
     expect(unzipSpy).toBeCalled();
     expect(loadInStorageSpy).toBeCalled();
@@ -47,7 +79,7 @@ describe('#loadExternalDependencies()', () => {
     });
     const dbRequest = indexedDB.open('FSH Playground Dependencies', version);
     dbRequest.onsuccess = async () => {
-      const dependencyDefs = loadExternalDependencies(defs, version);
+      const dependencyDefs = loadExternalDependencies(defs, version, []);
       await dependencyDefs;
       expect(unzipSpy).toBeCalledTimes(0);
       expect(loadInStorageSpy).toBeCalledTimes(0);

--- a/src/utils/Load.js
+++ b/src/utils/Load.js
@@ -1,7 +1,8 @@
 import tarStream from 'tar-stream';
 import zlib from 'zlib';
 import http from 'http';
-import { logger } from 'fsh-sushi/dist/utils';
+import { utils } from 'fsh-sushi';
+const logger = utils.logger;
 
 export function unzipDependencies(resources, dependency, id) {
   return new Promise((resolve) => {
@@ -32,9 +33,9 @@ export function unzipDependencies(resources, dependency, id) {
         logger.info(`Downloaded ${dependency}#${id}`);
       } else {
         if (id === 'current' || id === 'dev') {
-          console.log(`error FSHOnline does not currently support "current" or "dev" package versions`);
+          logger.error(`FSHOnline does not currently support "current" or "dev" package versions`);
         } else {
-          console.log(`error your dependency ${dependency}#${id} could not be loaded. Your output may be invalid.`);
+          logger.error(`your dependency ${dependency}#${id} could not be loaded. Your output may be invalid.`);
         }
         resolve(resources);
       }

--- a/src/utils/Load.js
+++ b/src/utils/Load.js
@@ -29,9 +29,13 @@ export function unzipDependencies(resources, dependency, id) {
       });
       if (res.statusCode < 400) {
         res.pipe(zlib.createGunzip()).pipe(extract);
-        logger.info(`Found ${dependency}#${id}`);
+        logger.info(`Downloaded ${dependency}#${id}`);
       } else {
-        console.log(`error your depdendency ${dependency}#${id} could not be loaded. Your output may be invalid.`);
+        if (id === 'current' || id === 'dev') {
+          console.log(`error FSHOnline does not currently support "current" or "dev" package versions`);
+        } else {
+          console.log(`error your dependency ${dependency}#${id} could not be loaded. Your output may be invalid.`);
+        }
         resolve(resources);
       }
     });

--- a/src/utils/Load.js
+++ b/src/utils/Load.js
@@ -2,69 +2,63 @@ import tarStream from 'tar-stream';
 import zlib from 'zlib';
 import http from 'http';
 
-export async function unzipDependencies(resources, dependencyArr) {
-  for (let i = 0; i < dependencyArr.length; i++) {
-    let dependency = dependencyArr[i][0];
-    let id = dependencyArr[i][1];
-    await new Promise((resolve) => {
-      http.get(`http://packages.fhir.org/${dependency}/${id}`, function (res) {
-        const extract = tarStream.extract();
-        // Unzip files
-        extract.on('entry', function (header, stream, next) {
-          let buf = '';
-          stream.on('data', function (chunk) {
-            buf += chunk.toString();
-          });
-          stream.on('end', function () {
-            try {
-              const resource = JSON.parse(buf);
-              if (resource.resourceType) {
-                resources.push(resource);
-              }
-            } catch {} //eslint-disable-line no-empty
-            next();
-          });
-          stream.resume();
+export function unzipDependencies(resources, dependency, id) {
+  return new Promise((resolve) => {
+    http.get(`https://packages.fhir.org/${dependency}/${id}`, function (res) {
+      const extract = tarStream.extract();
+      // Unzip files
+      extract.on('entry', function (header, stream, next) {
+        let buf = '';
+        stream.on('data', function (chunk) {
+          buf += chunk.toString();
         });
-        extract.on('finish', function () {
-          resolve(resources);
+        stream.on('end', function () {
+          try {
+            const resource = JSON.parse(buf);
+            if (resource.resourceType) {
+              resources.push(resource);
+            }
+          } catch {} //eslint-disable-line no-empty
+          next();
         });
-        if (res.statusCode < 400) {
-          res.pipe(zlib.createGunzip()).pipe(extract);
-        } else {
-          console.log(`error your depdendency ${dependency}#${id} could not be loaded. Your output may be invalid.`);
-          resolve(resources);
-        }
+        stream.resume();
       });
+      extract.on('finish', function () {
+        resolve(resources);
+      });
+      if (res.statusCode < 400) {
+        res.pipe(zlib.createGunzip()).pipe(extract);
+      } else {
+        console.log(`error your depdendency ${dependency}#${id} could not be loaded. Your output may be invalid.`);
+        resolve(resources);
+      }
     });
-  }
-  return resources;
+  });
 }
 
-export function loadDependenciesInStorage(database, resources) {
+export function loadDependenciesInStorage(database, resources, dependency, id) {
   return new Promise((resolve, reject) => {
     // Loads parsed json into indexDB
-    const transaction = database.transaction(['resources'], 'readwrite');
+    const transaction = database.transaction([`${dependency}${id}`], 'readwrite');
     transaction.oncomplete = () => {
-      console.log('hello');
       resolve();
     };
     transaction.onerror = (event) => {
       reject(event);
     };
-    const objectStore = transaction.objectStore('resources', { keyPath: ['id', 'resourceType'] });
+    const objectStore = transaction.objectStore(`${dependency}${id}`, { keyPath: ['id', 'resourceType'] });
     resources.forEach((res) => {
       objectStore.put(res);
     });
   });
 }
 
-export function loadAsFHIRDefs(FHIRdefs, database) {
+export function loadAsFHIRDefs(FHIRdefs, database, dependency, id) {
   // Convert database data into FHIR Definitions
   return new Promise((resolve, reject) => {
     const getData = database
-      .transaction(['resources'], 'readonly')
-      .objectStore('resources', { keyPath: ['id', 'resourceType'] })
+      .transaction([`${dependency}${id}`], 'readonly')
+      .objectStore(`${dependency}${id}`, { keyPath: ['id', 'resourceType'] })
       .openCursor();
     getData.onerror = function () {
       reject('There is an error getting data out!');

--- a/src/utils/Processing.js
+++ b/src/utils/Processing.js
@@ -13,11 +13,11 @@ export function fillTank(rawFSHes, config) {
   return new FSHTank(docs, config);
 }
 
-export function toUpgradeDatabase(dependencyArr) {
+export function toUpgradeDatabase(dependencyArr, databaseName = 'FSH Playground Dependencies') {
   let helperReturn = { shouldUpdate: false, version: 1 };
   return new Promise((resolve, reject) => {
     let database = null;
-    const OpenIDBRequest = indexedDB.open('FSH Playground Dependencies');
+    const OpenIDBRequest = indexedDB.open(databaseName);
     OpenIDBRequest.onsuccess = function (event) {
       database = event.target.result;
       let existingObjectStores = database.objectStoreNames;

--- a/src/utils/Processing.js
+++ b/src/utils/Processing.js
@@ -13,7 +13,7 @@ export function fillTank(rawFSHes, config) {
   return new FSHTank(docs, config);
 }
 
-export function toUpgradeDatabase(dependencyArr, databaseName = 'FSH Playground Dependencies') {
+export function checkForDatabaseUpgrade(dependencyArr, databaseName = 'FSH Playground Dependencies') {
   let helperReturn = { shouldUpdate: false, version: 1 };
   return new Promise((resolve, reject) => {
     let database = null;
@@ -63,8 +63,8 @@ export async function loadExternalDependencies(FHIRdefs, version, dependencyArr)
       for (let i = 0; i < dependencyArr.length; i++) {
         let resources = [];
         let shouldUnzip = false;
-        let dependency = dependencyArr[i][0];
-        let id = dependencyArr[i][1];
+        const dependency = dependencyArr[i][0];
+        const id = dependencyArr[i][1];
         if (newDependencies.includes(`${dependency}${id}`)) {
           shouldUnzip = true;
         }
@@ -79,12 +79,15 @@ export async function loadExternalDependencies(FHIRdefs, version, dependencyArr)
     };
     // If upgrade is needed to the version, the database does not yet exist
     OpenIDBRequest.onupgradeneeded = function (event) {
-      dependencyArr.push(['hl7.fhir.r4.core', '4.0.1']);
+      let findR4 = findIndex(dependencyArr, (elem) => elem[0] === 'hl7.fhir.r4.core' && elem[1] === '4.0.1');
+      if (findR4 < 0) {
+        dependencyArr.push(['hl7.fhir.r4.core', '4.0.1']);
+      }
       database = event.target.result;
       let existingObjectStores = database.objectStoreNames;
       for (let i = 0; i < dependencyArr.length; i++) {
-        let dependency = dependencyArr[i][0];
-        let id = dependencyArr[i][1];
+        const dependency = dependencyArr[i][0];
+        const id = dependencyArr[i][1];
         if (!existingObjectStores.contains(`${dependency}${id}`)) {
           database.createObjectStore(`${dependency}${id}`, {
             keyPath: ['id', 'resourceType']

--- a/src/utils/RunSUSHI.js
+++ b/src/utils/RunSUSHI.js
@@ -30,7 +30,7 @@ let startingWarns = 0;
  *
  * @returns Package with FHIR resources
  */
-export async function runSUSHI(input, config) {
+export async function runSUSHI(input, config, dependencyArr) {
   // Load dependencies
   let defs = new FHIRDefinitions();
   const version = 1;

--- a/src/utils/RunSUSHI.js
+++ b/src/utils/RunSUSHI.js
@@ -1,6 +1,6 @@
 import { pad, padStart, sample, padEnd } from 'lodash';
 import { fhirdefs, sushiExport, sushiImport, utils } from 'fsh-sushi';
-import { loadExternalDependencies, fillTank } from './Processing';
+import { loadExternalDependencies, fillTank, toUpgradeDatabase } from './Processing';
 
 const FSHTank = sushiImport.FSHTank;
 const RawFSH = sushiImport.RawFSH;
@@ -33,8 +33,12 @@ let startingWarns = 0;
 export async function runSUSHI(input, config, dependencyArr) {
   // Load dependencies
   let defs = new FHIRDefinitions();
-  const version = 1;
-  defs = await loadExternalDependencies(defs, version, dependencyArr);
+  let helperUpdate = await toUpgradeDatabase(dependencyArr);
+  if (helperUpdate.shouldUpdate) {
+    defs = await loadExternalDependencies(defs, helperUpdate.version + 1, dependencyArr);
+  } else {
+    defs = await loadExternalDependencies(defs, helperUpdate.version, dependencyArr);
+  }
 
   // Load and fill FSH Tank
   let tank = FSHTank;

--- a/src/utils/RunSUSHI.js
+++ b/src/utils/RunSUSHI.js
@@ -34,7 +34,7 @@ export async function runSUSHI(input, config, dependencyArr) {
   // Load dependencies
   let defs = new FHIRDefinitions();
   const version = 1;
-  defs = await loadExternalDependencies(defs, version);
+  defs = await loadExternalDependencies(defs, version, dependencyArr);
 
   // Load and fill FSH Tank
   let tank = FSHTank;

--- a/src/utils/RunSUSHI.js
+++ b/src/utils/RunSUSHI.js
@@ -1,6 +1,6 @@
 import { pad, padStart, sample, padEnd } from 'lodash';
 import { fhirdefs, sushiExport, sushiImport, utils } from 'fsh-sushi';
-import { loadExternalDependencies, fillTank, toUpgradeDatabase } from './Processing';
+import { loadExternalDependencies, fillTank, checkForDatabaseUpgrade } from './Processing';
 
 const FSHTank = sushiImport.FSHTank;
 const RawFSH = sushiImport.RawFSH;
@@ -33,7 +33,7 @@ let startingWarns = 0;
 export async function runSUSHI(input, config, dependencyArr) {
   // Load dependencies
   let defs = new FHIRDefinitions();
-  let helperUpdate = await toUpgradeDatabase(dependencyArr);
+  let helperUpdate = await checkForDatabaseUpgrade(dependencyArr);
   if (helperUpdate.shouldUpdate) {
     defs = await loadExternalDependencies(defs, helperUpdate.version + 1, dependencyArr);
   } else {


### PR DESCRIPTION
Address issue #23, supporting non r4 dependencies. Users now have the ability to input different dependency packages. Each is stored in their own indexeddb object store, and should only be downloaded once. However with any given program run, FSHOnline will only add those packages listed in the user input to the sushi-used FHIR Defs. 

Also added the used dependencies to the console log, and an error if the dependency cannot be found to the console log.
