### PR TITLE
Object Store Clean Up

### DIFF
--- a/src/tests/utils/Load.test.js
+++ b/src/tests/utils/Load.test.js
@@ -32,7 +32,7 @@ describe('#unzipDependencies', () => {
     const callbackFunction = getSpy.mock.calls[0][1];
     callbackFunction({ statusCode: 404 });
     expect(getSpy).toBeCalled();
-    expect(unzipPromise).resolves.toEqual({ emptyDependencies: ['hello123'], resourceArr: resources });
+    await expect(unzipPromise).resolves.toEqual({ emptyDependencies: ['hello123'], resourceArr: resources });
   });
 });
 

--- a/src/tests/utils/Load.test.js
+++ b/src/tests/utils/Load.test.js
@@ -8,6 +8,7 @@ const FHIRDefinitions = fhirdefs.FHIRDefinitions;
 
 describe('#unzipDependencies', () => {
   let getSpy = jest.SpyInstance;
+  // let getSpyBad = jest.SpyInstance;
   let tarSpy = jest.SpyInstance;
   let resources = [];
   beforeAll(() => {
@@ -29,6 +30,20 @@ describe('#unzipDependencies', () => {
     expect(getSpy).toBeCalled();
     expect(getSpy).toBeCalledWith('https://packages.fhir.org/hl7.fhir.r4.core/4.0.1', callbackFunction);
   });
+
+  //TODO - test failed http request
+
+  // it('should add failed http requests to a list of emptyDependencies', async () => {
+  //   getSpyBad = jest.spyOn(http, 'get').mockImplementation(() => {
+  //     const res = { statusCode: 404 };
+  //     return res;
+  //   });
+  //   const unzipReturn = await unzipDependencies(resources, 'hello', '123');
+  //   const callbackFunction = getSpy.mock.calls[0][1];
+  //   expect(getSpyBad).toBeCalled();
+  //   expect(getSpyBad).toBeCalledWith('https://packages.fhir.org/hello/123', callbackFunction);
+  //   expect(unzipReturn).toBe({ resourceArr: resources, emptyDependencies: ['hello#123'] });
+  // });
 });
 
 describe('#loadDependenciesInStorage', () => {

--- a/src/tests/utils/Load.test.js
+++ b/src/tests/utils/Load.test.js
@@ -32,7 +32,6 @@ describe('#unzipDependencies', () => {
     const callbackFunction = getSpy.mock.calls[0][1];
     callbackFunction({ statusCode: 404 });
     expect(getSpy).toBeCalled();
-    expect(getSpy).toBeCalledWith('https://packages.fhir.org/hello/123', callbackFunction);
     expect(unzipPromise).resolves.toEqual({ emptyDependencies: ['hello123'], resourceArr: resources });
   });
 });

--- a/src/tests/utils/Processing.test.js
+++ b/src/tests/utils/Processing.test.js
@@ -1,4 +1,4 @@
-import { loadExternalDependencies, fillTank, checkForDatabaseUpgrade } from '../../utils/Processing';
+import { loadExternalDependencies, fillTank, checkForDatabaseUpgrade, cleanDatabase } from '../../utils/Processing';
 import { fhirdefs, sushiImport } from 'fsh-sushi';
 import * as loadModule from '../../utils/Load';
 import 'fake-indexeddb/auto';
@@ -99,7 +99,7 @@ describe('#loadExternalDependencies()', () => {
     const defs = new FHIRDefinitions();
     const version = 2;
     const unzipSpy = jest.spyOn(loadModule, 'unzipDependencies').mockImplementation(() => {
-      return undefined;
+      return { resourceArr: [], emptyDependencies: [] };
     });
     const loadInStorageSpy = jest.spyOn(loadModule, 'loadDependenciesInStorage').mockImplementation(() => {
       return undefined;
@@ -118,7 +118,7 @@ describe('#loadExternalDependencies()', () => {
     const defs = new FHIRDefinitions();
     const version = 1;
     const unzipSpy = jest.spyOn(loadModule, 'unzipDependencies').mockImplementation(() => {
-      return undefined;
+      return { resourceArr: [], emptyDependencies: [] };
     });
     const loadInStorageSpy = jest.spyOn(loadModule, 'loadDependenciesInStorage').mockImplementation(() => {
       return undefined;
@@ -136,13 +136,13 @@ describe('#loadExternalDependencies()', () => {
     };
   });
 
-  it.only('should delete the the "resources" objectStore if it exists', async () => {
+  it('should delete the the "resources" objectStore if it exists', async () => {
     const defs = new FHIRDefinitions();
     const version = 1;
     let database = null;
     let existingObjectStores = null;
     const unzipSpy = jest.spyOn(loadModule, 'unzipDependencies').mockImplementation(() => {
-      return undefined;
+      return { resourceArr: [], emptyDependencies: [] };
     });
     const loadInStorageSpy = jest.spyOn(loadModule, 'loadDependenciesInStorage').mockImplementation(() => {
       return undefined;
@@ -150,23 +150,102 @@ describe('#loadExternalDependencies()', () => {
     const loadAsDefsSpy = jest.spyOn(loadModule, 'loadAsFHIRDefs').mockImplementation(() => {
       return undefined;
     });
-    await new Promise((resolve, reject) => {
-      const OpenIDBRequest = indexedDB.open('Test Database');
-      OpenIDBRequest.onsuccess = async function (event) {
+
+    // Open and set up a test database to have 'resources' objectStore
+    await new Promise((resolve) => {
+      const OpenIDBRequest = indexedDB.open('Test Database Resources', version);
+      OpenIDBRequest.onsuccess = async (event) => {
         database = event.target.result;
+        existingObjectStores = database.objectStoreNames;
+        database.close();
         resolve();
       };
-      OpenIDBRequest.onupgradeneeded = function (event) {
+      OpenIDBRequest.onupgradeneeded = async (event) => {
         database = event.target.result;
         database.createObjectStore('resources', { keyPath: ['id', 'resourceType'] });
       };
     });
-    console.log('here');
-    await loadExternalDependencies(defs, version + 1, [], 'Test Database');
+
+    // This call should upgrade our database and delete the 'resources' objectStore
+    await loadExternalDependencies(defs, version + 1, [], 'Test Database Resources');
+
+    // Reopen the database to update our existingObjectStores variable
+    await new Promise((resolve) => {
+      const OpenIDBRequest = indexedDB.open('Test Database Resources', version + 1);
+      OpenIDBRequest.onsuccess = async (event) => {
+        database = event.target.result;
+        existingObjectStores = database.objectStoreNames;
+        database.close();
+        resolve();
+      };
+    });
+
     expect(existingObjectStores.contains('resources')).toBeFalsy();
-    expect(unzipSpy).toBeCalledTimes(0);
-    expect(loadInStorageSpy).toBeCalledTimes(0);
+    expect(unzipSpy).toBeCalled();
+    expect(loadInStorageSpy).toBeCalled();
     expect(loadAsDefsSpy).toBeCalled();
+  });
+
+  it('should add empty objectStores to the emptyDependencies array', async () => {
+    const defs = new FHIRDefinitions();
+    const version = 2;
+    const unzipSpy = jest.spyOn(loadModule, 'unzipDependencies').mockImplementation(() => {
+      return { resourceArr: [], emptyDependencies: ['hello#123'] };
+    });
+    const loadInStorageSpy = jest.spyOn(loadModule, 'loadDependenciesInStorage').mockImplementation(() => {
+      return undefined;
+    });
+    const loadAsDefsSpy = jest.spyOn(loadModule, 'loadAsFHIRDefs').mockImplementation(() => {
+      return undefined;
+    });
+    const dependencyDefs = await loadExternalDependencies(defs, version, [], true);
+    expect(dependencyDefs).toEqual({ finalDefs: undefined, emptyDependencies: [['hello#123']] });
+    expect(unzipSpy).toBeCalled();
+    expect(loadInStorageSpy).toBeCalled();
+    expect(loadAsDefsSpy).toBeCalled();
+  });
+});
+
+describe('#cleanDatabase()', () => {
+  it('should delete empty objectStores', async () => {
+    let database = null;
+    const version = 1;
+    let existingObjectStores = null;
+    const emptyDependencies = [['test#123'], ['test456'], ['#789'], ['badObjectStore']];
+
+    // Open and set up a test database
+    await new Promise((resolve) => {
+      const OpenIDBRequest = indexedDB.open('Test Database Empty ObjectStores', version);
+      OpenIDBRequest.onsuccess = async (event) => {
+        database = event.target.result;
+        existingObjectStores = database.objectStoreNames;
+        database.close();
+        resolve();
+      };
+      OpenIDBRequest.onupgradeneeded = async (event) => {
+        database = event.target.result;
+        database.createObjectStore('test#123', { keyPath: ['id', 'resourceType'] });
+        database.createObjectStore('test456', { keyPath: ['id', 'resourceType'] });
+        database.createObjectStore('#789', { keyPath: ['id', 'resourceType'] });
+        database.createObjectStore('badObjectStore', { keyPath: ['id', 'resourceType'] });
+      };
+    });
+
+    // This call should upgrade our database and delete the empty objectStores
+    await cleanDatabase(emptyDependencies, version + 1, 'Test Database Empty ObjectStores');
+
+    // Reopen the database to check if our empty objectStores are gone
+    await new Promise((resolve) => {
+      const OpenIDBRequest = indexedDB.open('Test Database Empty ObjectStores', version + 1);
+      OpenIDBRequest.onsuccess = async (event) => {
+        database = event.target.result;
+        existingObjectStores = database.objectStoreNames;
+        database.close();
+        resolve();
+      };
+    });
+
+    expect(existingObjectStores).toHaveLength(0);
   });
 });
 

--- a/src/tests/utils/RunSUSHI.test.js
+++ b/src/tests/utils/RunSUSHI.test.js
@@ -15,12 +15,21 @@ const defaultConfig = {
 
 describe('#runSUSHI', () => {
   it('should return an undefined package when we get invalid FHIRDefinitions', async () => {
-    const FHIRDefs = new FHIRDefinitions();
-    const loadDefsSpy = jest.spyOn(processing, 'loadExternalDependencies').mockReset().mockResolvedValue(FHIRDefs);
+    const fhirDefs = new FHIRDefinitions();
+    const dependencyArr = [];
+    const loadDefsSpy = jest
+      .spyOn(processing, 'loadExternalDependencies')
+      .mockReset()
+      .mockResolvedValue({ finalDefs: fhirDefs, emptyDependencies: [] });
+    const checkForDatabaseUpgradeSpy = jest
+      .spyOn(processing, 'checkForDatabaseUpgrade')
+      .mockReset()
+      .mockResolvedValue({ shouldUpdate: false, version: 1 });
     const text =
       'Profile: FishPatient Parent: Patient Id: fish-patient Title: "Fish Patient" Description: "A patient that is a type of fish."';
-    const outPackage = await runSUSHI(text, defaultConfig);
+    const outPackage = await runSUSHI(text, defaultConfig, dependencyArr);
     expect(loadDefsSpy).toHaveBeenCalled();
+    expect(checkForDatabaseUpgradeSpy).toHaveBeenCalled();
     expect(outPackage).toBeUndefined();
   });
 
@@ -28,11 +37,19 @@ describe('#runSUSHI', () => {
     const FHIRDefs = new FHIRDefinitions();
     FHIRDefs.add(Patient);
     FHIRDefs.add(StructureDefinition);
-    const loadSpy = jest.spyOn(processing, 'loadExternalDependencies').mockReset().mockResolvedValue(FHIRDefs);
+    const loadSpy = jest
+      .spyOn(processing, 'loadExternalDependencies')
+      .mockReset()
+      .mockResolvedValue({ finalDefs: FHIRDefs, emptyDependencies: [] });
+    const checkForDatabaseUpgradeSpy = jest
+      .spyOn(processing, 'checkForDatabaseUpgrade')
+      .mockReset()
+      .mockResolvedValue({ shouldUpdate: false, version: 1 });
     const text =
       'Profile: FishPatient\nParent: Patient\nId: fish-patient\nTitle: "Fish Patient"\n Description: "A patient that is a type of fish."';
     const outPackage = await runSUSHI(text, defaultConfig);
     expect(loadSpy).toHaveBeenCalled();
+    expect(checkForDatabaseUpgradeSpy).toHaveBeenCalled();
     expect(outPackage.profiles).toHaveLength(1);
   });
 
@@ -40,7 +57,14 @@ describe('#runSUSHI', () => {
     const FHIRDefs = new FHIRDefinitions();
     FHIRDefs.add(Patient);
     FHIRDefs.add(StructureDefinition);
-    const loadSpy = jest.spyOn(processing, 'loadExternalDependencies').mockReset().mockResolvedValue(FHIRDefs);
+    const loadSpy = jest
+      .spyOn(processing, 'loadExternalDependencies')
+      .mockReset()
+      .mockResolvedValue({ finalDefs: FHIRDefs, emptyDependencies: [] });
+    const checkForDatabaseUpgradeSpy = jest
+      .spyOn(processing, 'checkForDatabaseUpgrade')
+      .mockReset()
+      .mockResolvedValue({ shouldUpdate: false, version: 1 });
     const fillTankSpy = jest
       .spyOn(processing, 'fillTank')
       .mockReset()
@@ -50,6 +74,7 @@ describe('#runSUSHI', () => {
     const input = 'Improper FSH code!';
     const outPackage = await runSUSHI(input, defaultConfig);
     expect(loadSpy).toHaveBeenCalled();
+    expect(checkForDatabaseUpgradeSpy).toHaveBeenCalled();
     expect(fillTankSpy).toHaveBeenCalled();
     expect(outPackage).toBeUndefined();
   });

--- a/src/tests/utils/RunSUSHI.test.js
+++ b/src/tests/utils/RunSUSHI.test.js
@@ -20,7 +20,7 @@ describe('#runSUSHI', () => {
     const loadDefsSpy = jest
       .spyOn(processing, 'loadExternalDependencies')
       .mockReset()
-      .mockResolvedValue({ finalDefs: fhirDefs, emptyDependencies: [] });
+      .mockResolvedValue({ defs: fhirDefs, emptyDependencies: [] });
     const checkForDatabaseUpgradeSpy = jest
       .spyOn(processing, 'checkForDatabaseUpgrade')
       .mockReset()
@@ -40,7 +40,7 @@ describe('#runSUSHI', () => {
     const loadSpy = jest
       .spyOn(processing, 'loadExternalDependencies')
       .mockReset()
-      .mockResolvedValue({ finalDefs: FHIRDefs, emptyDependencies: [] });
+      .mockResolvedValue({ defs: FHIRDefs, emptyDependencies: [] });
     const checkForDatabaseUpgradeSpy = jest
       .spyOn(processing, 'checkForDatabaseUpgrade')
       .mockReset()
@@ -60,7 +60,7 @@ describe('#runSUSHI', () => {
     const loadSpy = jest
       .spyOn(processing, 'loadExternalDependencies')
       .mockReset()
-      .mockResolvedValue({ finalDefs: FHIRDefs, emptyDependencies: [] });
+      .mockResolvedValue({ defs: FHIRDefs, emptyDependencies: [] });
     const checkForDatabaseUpgradeSpy = jest
       .spyOn(processing, 'checkForDatabaseUpgrade')
       .mockReset()

--- a/src/utils/Processing.js
+++ b/src/utils/Processing.js
@@ -35,7 +35,7 @@ export function cleanDatabase(emptyDependencies, version, databaseName = 'FSH Pl
           objStore.onsuccess = (event) => {
             let items = event.target.result;
             if (items.length === 0 && !mergedEmpties.includes(objectStore)) {
-              emptyDependencies.push(objectStore);
+              mergedEmpties.push(objectStore);
             }
             resolve();
           };
@@ -63,10 +63,14 @@ export function checkForDatabaseUpgrade(dependencyArr, databaseName = 'FSH Playg
       database = event.target.result;
       let existingObjectStores = database.objectStoreNames;
       helperReturn.version = database.version;
-      if (existingObjectStores.contains('resources')) {
-        helperReturn.shouldUpdate = true;
-      }
-      if (existingObjectStores.length === 0 || dependencyArr.length === 0) {
+      // if (existingObjectStores.contains('resources')) {
+      //   helperReturn.shouldUpdate = true;
+      // }
+      if (
+        existingObjectStores.length === 0 ||
+        dependencyArr.length === 0 ||
+        existingObjectStores.contains('resources')
+      ) {
         helperReturn.shouldUpdate = true;
         database.close();
         resolve(helperReturn);
@@ -101,7 +105,7 @@ export async function loadExternalDependencies(
   return new Promise((resolve, reject) => {
     let database = null;
     let newDependencies = [];
-    let returnPackage = { finalDefs: FHIRDefinitions, emptyDependencies: [] };
+    let returnPackage = { defs: FHIRDefinitions, emptyDependencies: [] };
     const OpenIDBRequest = indexedDB.open(databaseName, version);
 
     // If successful the database exists
@@ -126,7 +130,7 @@ export async function loadExternalDependencies(
           }
           await loadDependenciesInStorage(database, unzipReturn.resourceArr, dependency, id);
         }
-        returnPackage.finalDefs = await loadAsFHIRDefs(FHIRdefs, database, dependency, id);
+        returnPackage.defs = await loadAsFHIRDefs(FHIRdefs, database, dependency, id);
       }
       database.close();
       resolve(returnPackage);

--- a/src/utils/Processing.js
+++ b/src/utils/Processing.js
@@ -1,6 +1,6 @@
 import { fhirdefs, sushiImport, utils } from 'fsh-sushi';
 import { loadAsFHIRDefs, loadDependenciesInStorage, unzipDependencies } from './Load';
-import { findIndex } from 'lodash';
+import { findIndex, flatten } from 'lodash';
 
 const logger = utils.logger;
 const FHIRDefinitions = fhirdefs.FHIRDefinitions;
@@ -11,6 +11,47 @@ export function fillTank(rawFSHes, config) {
   logger.info('Importing FSH text...');
   const docs = importText(rawFSHes);
   return new FSHTank(docs, config);
+}
+
+export function cleanDatabase(emptyDependencies, version, databaseName = 'FSH Playground Dependencies') {
+  const mergedEmpties = flatten(emptyDependencies);
+  return new Promise((resolve, reject) => {
+    let database = null;
+    const OpenIDBRequest = indexedDB.open(databaseName, version);
+    OpenIDBRequest.onsuccess = function (event) {
+      database = event.target.result;
+      database.close();
+      resolve();
+    };
+    OpenIDBRequest.onupgradeneeded = async function (event) {
+      database = event.target.result;
+      let existingObjectStores = database.objectStoreNames;
+
+      // Checks existing objectStores to see if any are empty - failsafe for users who previously had blank objectStores created
+      for (let objectStore of existingObjectStores) {
+        await new Promise((resolve) => {
+          let transaction = event.target.transaction;
+          const objStore = transaction.objectStore(`${objectStore}`).getAll();
+          objStore.onsuccess = (event) => {
+            let items = event.target.result;
+            if (items.length === 0 && !mergedEmpties.includes(objectStore)) {
+              emptyDependencies.push(objectStore);
+            }
+            resolve();
+          };
+        });
+      }
+      // Deletes objectStores that are empty
+      for (let i = 0; i < mergedEmpties.length; i++) {
+        if (existingObjectStores.contains(mergedEmpties[i])) {
+          database.deleteObjectStore(mergedEmpties[i]);
+        }
+      }
+    };
+    OpenIDBRequest.onerror = function (event) {
+      reject(event);
+    };
+  });
 }
 
 export function checkForDatabaseUpgrade(dependencyArr, databaseName = 'FSH Playground Dependencies') {
@@ -54,17 +95,17 @@ export async function loadExternalDependencies(
   FHIRdefs,
   version,
   dependencyArr,
-  databaseName = 'FSH Playground Dependencies'
+  databaseName = 'FSH Playground Dependencies',
+  shouldUnzip = false
 ) {
   return new Promise((resolve, reject) => {
     let database = null;
     let newDependencies = [];
-    let finalDefs = FHIRDefinitions;
+    let returnPackage = { finalDefs: FHIRDefinitions, emptyDependencies: [] };
     const OpenIDBRequest = indexedDB.open(databaseName, version);
+
     // If successful the database exists
-    console.log('here');
     OpenIDBRequest.onsuccess = async function (event) {
-      console.log('ahhhhh');
       database = event.target.result;
       let findR4 = findIndex(dependencyArr, (elem) => elem[0] === 'hl7.fhir.r4.core' && elem[1] === '4.0.1');
       if (findR4 < 0) {
@@ -72,21 +113,25 @@ export async function loadExternalDependencies(
       }
       for (let i = 0; i < dependencyArr.length; i++) {
         let resources = [];
-        let shouldUnzip = false;
+        shouldUnzip = false;
         const dependency = dependencyArr[i][0];
         const id = dependencyArr[i][1];
         if (newDependencies.includes(`${dependency}${id}`)) {
           shouldUnzip = true;
         }
         if (shouldUnzip) {
-          resources = await unzipDependencies(resources, dependency, id);
-          await loadDependenciesInStorage(database, resources, dependency, id);
+          let unzipReturn = await unzipDependencies(resources, dependency, id);
+          if (unzipReturn.emptyDependencies.length !== 0) {
+            returnPackage.emptyDependencies.push(unzipReturn.emptyDependencies);
+          }
+          await loadDependenciesInStorage(database, unzipReturn.resourceArr, dependency, id);
         }
-        finalDefs = await loadAsFHIRDefs(FHIRdefs, database, dependency, id);
+        returnPackage.finalDefs = await loadAsFHIRDefs(FHIRdefs, database, dependency, id);
       }
       database.close();
-      resolve(finalDefs);
+      resolve(returnPackage);
     };
+
     // If upgrade is needed to the version, the database does not yet exist
     OpenIDBRequest.onupgradeneeded = function (event) {
       let findR4 = findIndex(dependencyArr, (elem) => elem[0] === 'hl7.fhir.r4.core' && elem[1] === '4.0.1');
@@ -109,9 +154,9 @@ export async function loadExternalDependencies(
         }
       }
     };
+
     // Checks if there is an error
     OpenIDBRequest.onerror = function (event) {
-      console.log('ererrerror');
       reject(event);
     };
   });

--- a/src/utils/Processing.js
+++ b/src/utils/Processing.js
@@ -63,9 +63,6 @@ export function checkForDatabaseUpgrade(dependencyArr, databaseName = 'FSH Playg
       database = event.target.result;
       let existingObjectStores = database.objectStoreNames;
       helperReturn.version = database.version;
-      // if (existingObjectStores.contains('resources')) {
-      //   helperReturn.shouldUpdate = true;
-      // }
       if (
         existingObjectStores.length === 0 ||
         dependencyArr.length === 0 ||
@@ -144,6 +141,9 @@ export async function loadExternalDependencies(
       }
       database = event.target.result;
       let existingObjectStores = database.objectStoreNames;
+      if (existingObjectStores.contains('resources')) {
+        database.deleteObjectStore('resources');
+      }
       for (let i = 0; i < dependencyArr.length; i++) {
         const dependency = dependencyArr[i][0];
         const id = dependencyArr[i][1];
@@ -152,9 +152,6 @@ export async function loadExternalDependencies(
             keyPath: ['id', 'resourceType']
           });
           newDependencies.push(`${dependency}${id}`);
-        }
-        if (existingObjectStores.contains('resources')) {
-          database.deleteObjectStore('resources');
         }
       }
     };

--- a/src/utils/RunSUSHI.js
+++ b/src/utils/RunSUSHI.js
@@ -38,10 +38,10 @@ export async function runSUSHI(input, config, dependencyArr) {
 
   if (helperUpdate.shouldUpdate) {
     loadExternalDependenciesReturn = await loadExternalDependencies(defs, helperUpdate.version + 1, dependencyArr);
-    defs = loadExternalDependenciesReturn.finalDefs;
+    defs = loadExternalDependenciesReturn.defs;
   } else {
     loadExternalDependenciesReturn = await loadExternalDependencies(defs, helperUpdate.version, dependencyArr);
-    defs = loadExternalDependenciesReturn.finalDefs;
+    defs = loadExternalDependenciesReturn.defs;
   }
 
   // Cleans out database of any empty objectStores

--- a/src/utils/RunSUSHI.js
+++ b/src/utils/RunSUSHI.js
@@ -1,6 +1,6 @@
 import { pad, padStart, sample, padEnd } from 'lodash';
 import { fhirdefs, sushiExport, sushiImport, utils } from 'fsh-sushi';
-import { loadExternalDependencies, fillTank, checkForDatabaseUpgrade } from './Processing';
+import { loadExternalDependencies, fillTank, checkForDatabaseUpgrade, cleanDatabase } from './Processing';
 
 const FSHTank = sushiImport.FSHTank;
 const RawFSH = sushiImport.RawFSH;
@@ -34,11 +34,18 @@ export async function runSUSHI(input, config, dependencyArr) {
   // Load dependencies
   let defs = new FHIRDefinitions();
   let helperUpdate = await checkForDatabaseUpgrade(dependencyArr);
+  let loadExternalDependenciesReturn = { defs, emptyDependencies: [] };
+
   if (helperUpdate.shouldUpdate) {
-    defs = await loadExternalDependencies(defs, helperUpdate.version + 1, dependencyArr);
+    loadExternalDependenciesReturn = await loadExternalDependencies(defs, helperUpdate.version + 1, dependencyArr);
+    defs = loadExternalDependenciesReturn.finalDefs;
   } else {
-    defs = await loadExternalDependencies(defs, helperUpdate.version, dependencyArr);
+    loadExternalDependenciesReturn = await loadExternalDependencies(defs, helperUpdate.version, dependencyArr);
+    defs = loadExternalDependenciesReturn.finalDefs;
   }
+
+  // Cleans out database of any empty objectStores
+  await cleanDatabase(loadExternalDependenciesReturn.emptyDependencies, helperUpdate.version + 2);
 
   // Load and fill FSH Tank
   let tank = FSHTank;


### PR DESCRIPTION
Deletes empty ObjectStores that users have created in the past, the old 'resources' object store, and deletes any empty ObjectStores that users may create by entering unrecognized dependencies. Addresses comments made here: https://github.com/FSHSchool/FSHOnline/pull/28#issuecomment-754134629.

Note: there is still one test in `Load.test.js` that must be fixed or determined unnecessary.