### PR TITLE
Update to SUSHI v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6605,9 +6605,9 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-1.1.0.tgz",
-      "integrity": "sha512-0R+jT3vwxiXxyZ4gaH5E0liUf56edgQm+gmCIHO4TzAA/YYeu6IlWhVS+mu3yP1Fi8JJMkERRwnMYrfBI5K2CQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-1.2.0.tgz",
+      "integrity": "sha512-3jnKoGrXFixskcXjxJlAw3bdTP97UzVdNQ8MihGrQJ/TwKbu0emt8SC0Fadp5Ob+ztEMixqzB6cqfIHwHpARPg==",
       "requires": {
         "antlr4": "~4.8.0",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bitly": "^7.1.0",
     "browserify-zlib": "^0.2.0",
     "codemirror": "^5.54.0",
-    "fsh-sushi": "^1.1.0",
+    "fsh-sushi": "^1.2.0",
     "lodash": "^4.17.19",
     "null-loader": "^4.0.0",
     "react": "^16.13.1",

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -215,7 +215,7 @@ export default function SUSHIControls(props) {
               margin="dense"
               fullWidth
               label="Dependencies"
-              helperText="Format: packageId#version, packageId#version (ex. hl7.fhir.us.core#3.1.1)"
+              helperText="Format: packageId#version, packageId#version (e.g., hl7.fhir.us.core#3.1.1)"
               defaultValue={dependencies}
               onChange={updateDependencyString}
             />

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -215,7 +215,7 @@ export default function SUSHIControls(props) {
               margin="dense"
               fullWidth
               label="Dependencies"
-              helperText="dependencyID#version, dependencyID#version"
+              helperText="Format: packageId#version, packageId#version (ex. hl7.fhir.us.core#3.1.1)"
               defaultValue={dependencies}
               onChange={updateDependencyString}
             />

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -40,7 +40,7 @@ export default function TopBar() {
                 <ThemeProvider theme={theme}>
                   <StylesProvider injectFirst>
                     <Typography order={2} classes={{ root: 'versionText' }}>
-                      Powered by SUSHI v1.1.0
+                      Powered by SUSHI v1.2.0
                     </Typography>
                   </StylesProvider>
                 </ThemeProvider>


### PR DESCRIPTION
This PR updates the installed SUSHI to the latest version, v1.2.0. This SUSHI update has a fix for using regex lookbehind assertions, and it fixes #34 so the app will load in Safari. 