### PR TITLE
Update SUSHI to v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6605,9 +6605,9 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-1.2.0.tgz",
-      "integrity": "sha512-3jnKoGrXFixskcXjxJlAw3bdTP97UzVdNQ8MihGrQJ/TwKbu0emt8SC0Fadp5Ob+ztEMixqzB6cqfIHwHpARPg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-1.3.0.tgz",
+      "integrity": "sha512-fcc1UOJyYd3QNWL8UrTRwWtaDIOxlQfvt/DhkhTlPBRNB1VSY9pndnXi+0gTPNptzWU32dyT/OBhR+tOXut85Q==",
       "requires": {
         "antlr4": "~4.8.0",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bitly": "^7.1.0",
     "browserify-zlib": "^0.2.0",
     "codemirror": "^5.54.0",
-    "fsh-sushi": "^1.2.0",
+    "fsh-sushi": "^1.3.0",
     "lodash": "^4.17.19",
     "null-loader": "^4.0.0",
     "react": "^16.13.1",

--- a/src/components/CodeMirrorComponent.js
+++ b/src/components/CodeMirrorComponent.js
@@ -25,7 +25,7 @@ CodeMirror.defineSimpleMode('fsh', {
     },
     {
       // NOTE: Original regex has (?<=\s) at start and (?=\s) at the end. However, there are known shortcomings with look ahead/look behind with the simple mode approach
-      regex: /\b(and|codes|contains|exclude|from|includes|is-a|is-not-a|named|obeys|only|or|system|units|valueset|where|D|MS|N|SU|TU|\\?!)\b/,
+      regex: /\b(and|codes|contains|descendent-of|exclude|exists|from|generalizes|include|in|insert|is-a|is-not-a|named|not-in|obeys|only|or|regex|system|units|valueset|where|D|MS|N|SU|TU|\\?!)\b/,
       token: 'def'
     },
     {

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -40,7 +40,7 @@ export default function TopBar() {
                 <ThemeProvider theme={theme}>
                   <StylesProvider injectFirst>
                     <Typography order={2} classes={{ root: 'versionText' }}>
-                      Powered by SUSHI v1.2.0
+                      Powered by SUSHI v1.3.0
                     </Typography>
                   </StylesProvider>
                 </ThemeProvider>


### PR DESCRIPTION
Updates SUSHI to v1.3.0. This update should resolve the issue reported on SUSHI about an unexpected error message ([here](https://github.com/FHIR/sushi/issues/750)).