### PR TITLE
Collapsible console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1515,6 +1515,14 @@
         "react-transition-group": "^4.4.0"
       }
     },
+    "@material-ui/icons": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
+      "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material-ui/core": "^4.10.2",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/src/App.js
+++ b/src/App.js
@@ -14,20 +14,24 @@ const useStyles = makeStyles((theme) => ({
     flexGrow: 1
   },
   itemTop: {
-    height: '75vh'
+    height: '85vh'
   },
-  itemBottom: {
-    height: '25vh'
+  console: {
+    height: '20vh'
   }
 }));
 
 const log = console.log; //eslint-disable-line no-unused-vars
 let consoleMessages = [];
 let errorAndWarningMessages = [];
+let errorCount = 0;
+let warningCount = 0;
 console.log = function getMessages(message) {
   consoleMessages.push(message);
   if (message && (message.startsWith('error') || message.startsWith('warn'))) {
     errorAndWarningMessages.push(message);
+    if (message.startsWith('error')) errorCount++;
+    else warningCount++;
   }
 };
 
@@ -56,6 +60,7 @@ export default function App(props) {
   const [initialText, setInitialText] = useState('Edit FSH here!');
   const [outputText, setOutputText] = useState('Your JSON Output Will Display Here: ');
   const [isOutputObject, setIsOutputObject] = useState(false);
+  const [expandConsole, setExpandConsole] = useState(false);
 
   useEffect(() => {
     async function waitForFSH() {
@@ -67,6 +72,8 @@ export default function App(props) {
   function resetLogMessages() {
     consoleMessages = [];
     errorAndWarningMessages = [];
+    errorCount = 0;
+    warningCount = 0;
   }
 
   function handleSUSHIControls(doRunSUSHI, sushiOutput, isObject) {
@@ -84,10 +91,10 @@ export default function App(props) {
       <TopBar />
       <SUSHIControls onClick={handleSUSHIControls} text={inputText} resetLogMessages={resetLogMessages} />
       <Grid className={classes.container} container>
-        <Grid className={classes.itemTop} item xs={6}>
+        <Grid style={{ height: expandConsole ? '55vh' : '85vh' }} item xs={6}>
           <CodeMirrorComponent value={inputText} initialText={initialText} updateTextValue={updateInputTextValue} />
         </Grid>
-        <Grid className={classes.itemTop} item xs={6}>
+        <Grid style={{ height: expandConsole ? '55vh' : '85vh' }} item xs={6}>
           <JSONOutput
             displaySUSHI={doRunSUSHI}
             text={outputText}
@@ -95,8 +102,15 @@ export default function App(props) {
             errorsAndWarnings={errorAndWarningMessages}
           />
         </Grid>
-        <Grid className={classes.itemBottom} item xs={12}>
-          <ConsoleComponent consoleMessages={consoleMessages} />
+        <Grid item xs={12}>
+          <ConsoleComponent
+            style={{ height: expandConsole ? '35vh' : '20vh' }}
+            consoleMessages={consoleMessages}
+            warningCount={warningCount}
+            errorCount={errorCount}
+            expandConsole={expandConsole}
+            setExpandConsole={setExpandConsole}
+          />
         </Grid>
       </Grid>
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,8 @@ const useStyles = makeStyles((theme) => ({
 const log = console.log; //eslint-disable-line no-unused-vars
 let consoleMessages = [];
 let errorAndWarningMessages = [];
+let errorString = '';
+let warningString = '';
 let errorCount = 0;
 let warningCount = 0;
 console.log = function getMessages(message) {
@@ -32,6 +34,14 @@ console.log = function getMessages(message) {
     errorAndWarningMessages.push(message);
     if (message.startsWith('error')) errorCount++;
     else warningCount++;
+  }
+  if (errorCount > 0) {
+    errorString = `${errorCount} Error`;
+    if (errorCount !== 1) errorString += 's';
+  }
+  if (warningCount > 0) {
+    warningString = `${warningCount} Warning`;
+    if (warningCount !== 1) warningString += 's';
   }
 };
 
@@ -72,6 +82,8 @@ export default function App(props) {
   function resetLogMessages() {
     consoleMessages = [];
     errorAndWarningMessages = [];
+    errorString = '';
+    warningString = '';
     errorCount = 0;
     warningCount = 0;
   }
@@ -106,8 +118,8 @@ export default function App(props) {
           <ConsoleComponent
             style={{ height: expandConsole ? '35vh' : '20vh' }}
             consoleMessages={consoleMessages}
-            warningCount={warningCount}
-            errorCount={errorCount}
+            warningCount={warningString}
+            errorCount={errorString}
             expandConsole={expandConsole}
             setExpandConsole={setExpandConsole}
           />

--- a/src/App.js
+++ b/src/App.js
@@ -12,12 +12,6 @@ import SUSHIControls from './components/SUSHIControls';
 const useStyles = makeStyles((theme) => ({
   container: {
     flexGrow: 1
-  },
-  itemTop: {
-    height: '85vh'
-  },
-  console: {
-    height: '20vh'
   }
 }));
 
@@ -99,7 +93,7 @@ export default function App(props) {
   }
 
   return (
-    <div className="root">
+    <div className="root" style={{ overflow: 'hidden', height: '100vh' }}>
       <TopBar />
       <SUSHIControls onClick={handleSUSHIControls} text={inputText} resetLogMessages={resetLogMessages} />
       <Grid className={classes.container} container>
@@ -116,7 +110,6 @@ export default function App(props) {
         </Grid>
         <Grid item xs={12}>
           <ConsoleComponent
-            style={{ height: expandConsole ? '35vh' : '20vh' }}
             consoleMessages={consoleMessages}
             warningCount={warningString}
             errorCount={errorString}

--- a/src/App.js
+++ b/src/App.js
@@ -19,11 +19,11 @@ const useStyles = makeStyles((theme) => ({
   },
   collapsedMain: {
     width: '100%',
-    height: 'calc(100vh - 120px - 300px)'
+    height: 'calc(100vh - 116px - 300px)'
   },
   expandedMain: {
     width: '100%',
-    height: 'calc(100vh - 120px - 25px)'
+    height: 'calc(100vh - 116px - 25px)'
   },
   collapsedConsole: {
     height: '25px',
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme) => ({
     width: '100%'
   },
   top: {
-    height: '120px'
+    height: '116px'
   }
 }));
 

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,30 @@ import SUSHIControls from './components/SUSHIControls';
 
 const useStyles = makeStyles((theme) => ({
   container: {
+    height: '100%',
     flexGrow: 1
+  },
+  fullHeightGrid: {
+    height: '100%'
+  },
+  collapsedMain: {
+    width: '100%',
+    height: 'calc(100vh - 120px - 300px)'
+  },
+  expandedMain: {
+    width: '100%',
+    height: 'calc(100vh - 120px - 25px)'
+  },
+  collapsedConsole: {
+    height: '25px',
+    width: '100%'
+  },
+  expandedConsole: {
+    height: '300px',
+    width: '100%'
+  },
+  top: {
+    height: '120px'
   }
 }));
 
@@ -93,31 +116,35 @@ export default function App(props) {
   }
 
   return (
-    <div className="root" style={{ overflow: 'hidden', height: '100vh' }}>
-      <TopBar />
-      <SUSHIControls onClick={handleSUSHIControls} text={inputText} resetLogMessages={resetLogMessages} />
-      <Grid className={classes.container} container>
-        <Grid style={{ height: expandConsole ? '55vh' : '85.3vh' }} item xs={6}>
-          <CodeMirrorComponent value={inputText} initialText={initialText} updateTextValue={updateInputTextValue} />
+    <div className="root" style={{ height: '100vh' }}>
+      <div className={classes.top}>
+        <TopBar />
+        <SUSHIControls onClick={handleSUSHIControls} text={inputText} resetLogMessages={resetLogMessages} />
+      </div>
+      <div className={expandConsole ? classes.collapsedMain : classes.expandedMain}>
+        <Grid className={classes.container} container>
+          <Grid item xs={6} className={classes.fullHeightGrid}>
+            <CodeMirrorComponent value={inputText} initialText={initialText} updateTextValue={updateInputTextValue} />
+          </Grid>
+          <Grid item xs={6} className={classes.fullHeightGrid}>
+            <JSONOutput
+              displaySUSHI={doRunSUSHI}
+              text={outputText}
+              isObject={isOutputObject}
+              errorsAndWarnings={errorAndWarningMessages}
+            />
+          </Grid>
         </Grid>
-        <Grid style={{ height: expandConsole ? '54.6vh' : '84.9vh' }} item xs={6}>
-          <JSONOutput
-            displaySUSHI={doRunSUSHI}
-            text={outputText}
-            isObject={isOutputObject}
-            errorsAndWarnings={errorAndWarningMessages}
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <ConsoleComponent
-            consoleMessages={consoleMessages}
-            warningCount={warningString}
-            errorCount={errorString}
-            expandConsole={expandConsole}
-            setExpandConsole={setExpandConsole}
-          />
-        </Grid>
-      </Grid>
+      </div>
+      <div className={expandConsole ? classes.expandedConsole : classes.collapsedConsole}>
+        <ConsoleComponent
+          consoleMessages={consoleMessages}
+          warningCount={warningString}
+          errorCount={errorString}
+          expandConsole={expandConsole}
+          setExpandConsole={setExpandConsole}
+        />
+      </div>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -91,10 +91,10 @@ export default function App(props) {
       <TopBar />
       <SUSHIControls onClick={handleSUSHIControls} text={inputText} resetLogMessages={resetLogMessages} />
       <Grid className={classes.container} container>
-        <Grid style={{ height: expandConsole ? '55vh' : '85vh' }} item xs={6}>
+        <Grid style={{ height: expandConsole ? '55vh' : '86vh' }} item xs={6}>
           <CodeMirrorComponent value={inputText} initialText={initialText} updateTextValue={updateInputTextValue} />
         </Grid>
-        <Grid style={{ height: expandConsole ? '55vh' : '85vh' }} item xs={6}>
+        <Grid style={{ height: expandConsole ? '54.6vh' : '85.6vh' }} item xs={6}>
           <JSONOutput
             displaySUSHI={doRunSUSHI}
             text={outputText}

--- a/src/App.js
+++ b/src/App.js
@@ -97,10 +97,10 @@ export default function App(props) {
       <TopBar />
       <SUSHIControls onClick={handleSUSHIControls} text={inputText} resetLogMessages={resetLogMessages} />
       <Grid className={classes.container} container>
-        <Grid style={{ height: expandConsole ? '55vh' : '86vh' }} item xs={6}>
+        <Grid style={{ height: expandConsole ? '55vh' : '85.3vh' }} item xs={6}>
           <CodeMirrorComponent value={inputText} initialText={initialText} updateTextValue={updateInputTextValue} />
         </Grid>
-        <Grid style={{ height: expandConsole ? '54.6vh' : '85.6vh' }} item xs={6}>
+        <Grid style={{ height: expandConsole ? '54.6vh' : '84.9vh' }} item xs={6}>
           <JSONOutput
             displaySUSHI={doRunSUSHI}
             text={outputText}

--- a/src/components/ConsoleComponent.js
+++ b/src/components/ConsoleComponent.js
@@ -5,6 +5,7 @@ import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import ImportExportIcon from '@material-ui/icons/ImportExport';
 import WarningIcon from '@material-ui/icons/Warning';
 import ErrorIcon from '@material-ui/icons/Error';
+import CheckIcon from '@material-ui/icons/Check';
 
 const useStyles = makeStyles((theme) => ({
   consoleControls: {
@@ -25,6 +26,9 @@ const useStyles = makeStyles((theme) => ({
   },
   error: {
     color: 'red'
+  },
+  success: {
+    color: 'green'
   },
   pre: {
     margin: '0px'
@@ -53,10 +57,17 @@ export default function Console(props) {
         <Button onClick={toggleExpandConsole}>
           {props.expandConsole ? 'Collapse Console   ' : 'Expand Console   '}
           <ImportExportIcon />
-          <WarningIcon className={classes.warning} />
-          {props.warningCount} Warnings
-          <ErrorIcon className={classes.error} />
-          {props.errorCount} Errors
+          <WarningIcon style={{ display: props.warningCount ? 'block' : 'none' }} className={classes.warning} />
+          {props.warningCount ? `${props.warningCount}` : ''}
+          <ErrorIcon style={{ display: props.errorCount ? 'block' : 'none' }} className={classes.error} />
+          {props.errorCount ? `${props.errorCount}` : ''}
+          <CheckIcon
+            className={classes.success}
+            style={{
+              display: props.consoleMessages.length > 0 && !props.warningCount && !props.errorCount ? 'block' : 'none'
+            }}
+          />
+          {props.consoleMessages.length > 0 && !props.warningCount && !props.errorCount ? `Success!` : ''}
         </Button>
       </Box>
       <Box

--- a/src/components/ConsoleComponent.js
+++ b/src/components/ConsoleComponent.js
@@ -9,20 +9,19 @@ import CheckIcon from '@material-ui/icons/Check';
 
 const useStyles = makeStyles((theme) => ({
   consoleControls: {
-    padding: theme.spacing(1),
     background: '#C0C0C0',
-    height: '.8vh',
+    height: '2.5vh',
     display: 'flex;',
     alignItems: 'center',
     justifyContent: 'left'
   },
   box: {
-    padding: theme.spacing(2),
+    padding: theme.spacing(1),
     color: theme.palette.common.white,
     background: theme.palette.common.black,
-    height: '28vh',
-    borderBottom: '4px solid #2c4f85',
-    overflow: 'scroll'
+    height: '30vh',
+    overflow: 'scroll',
+    borderBottom: '4px solid #2c4f85'
   },
   warning: {
     color: 'khaki'

--- a/src/components/ConsoleComponent.js
+++ b/src/components/ConsoleComponent.js
@@ -1,14 +1,32 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Box, Typography } from '@material-ui/core';
+import { Box, Button, Typography } from '@material-ui/core';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import ImportExportIcon from '@material-ui/icons/ImportExport';
+import WarningIcon from '@material-ui/icons/Warning';
+import ErrorIcon from '@material-ui/icons/Error';
 
 const useStyles = makeStyles((theme) => ({
+  consoleControls: {
+    padding: theme.spacing(1),
+    color: '#C0C0C0',
+    background: '#C0C0C0',
+    height: '1vh',
+    display: 'flex;',
+    alignItems: 'center',
+    justifyContent: 'left'
+  },
   box: {
     padding: theme.spacing(2),
     color: theme.palette.common.white,
     background: theme.palette.common.black,
     height: '200%'
+  },
+  warning: {
+    color: 'khaki'
+  },
+  error: {
+    color: 'red'
   },
   pre: {
     margin: '0px'
@@ -24,9 +42,27 @@ const theme = createMuiTheme({
 export default function Console(props) {
   const classes = useStyles();
 
+  const toggleExpandConsole = () => {
+    props.setExpandConsole(!props.expandConsole);
+  };
+
   return (
     <ThemeProvider theme={theme}>
-      <Box className={classes.box} overflow="scroll">
+      <Box className={classes.consoleControls}>
+        <Button onClick={toggleExpandConsole}>
+          {props.expandConsole ? 'Collapse Console   ' : 'Expand Console   '}
+          <ImportExportIcon />
+          <WarningIcon className={classes.warning} />
+          {props.warningCount} Warnings
+          <ErrorIcon className={classes.error} />
+          {props.errorCount} Errors
+        </Button>
+      </Box>
+      <Box
+        style={{ display: props.expandConsole ? 'block' : 'none', height: '30vh' }}
+        className={classes.box}
+        overflow="scroll"
+      >
         <Typography variant="subtitle1">Console</Typography>
         {props.consoleMessages.map((message, i) => {
           return (

--- a/src/components/ConsoleComponent.js
+++ b/src/components/ConsoleComponent.js
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(1),
     color: theme.palette.common.white,
     background: theme.palette.common.black,
-    height: '30vh',
+    height: '29vh',
     overflow: 'scroll',
     borderBottom: '4px solid #2c4f85'
   },

--- a/src/components/ConsoleComponent.js
+++ b/src/components/ConsoleComponent.js
@@ -10,17 +10,19 @@ import CheckIcon from '@material-ui/icons/Check';
 const useStyles = makeStyles((theme) => ({
   consoleControls: {
     background: '#C0C0C0',
-    height: '2.5vh',
+    height: '25px',
+    boxSizing: 'border-box',
     display: 'flex;',
     alignItems: 'center',
     justifyContent: 'left'
   },
   box: {
-    padding: theme.spacing(1),
+    paddingLeft: theme.spacing(1),
     color: theme.palette.common.white,
     background: theme.palette.common.black,
-    height: '29vh',
+    height: 'calc(100% - 25px)',
     overflow: 'scroll',
+    boxSizing: 'border-box',
     borderBottom: '4px solid #2c4f85'
   },
   warning: {
@@ -54,9 +56,9 @@ export default function Console(props) {
     <ThemeProvider theme={theme}>
       <Box
         className={classes.consoleControls}
-        style={{ borderBottom: !props.expandConsole ? '6px solid #2c4f85' : '' }}
+        style={{ borderBottom: !props.expandConsole ? '4px solid #2c4f85' : '' }}
       >
-        <Button onClick={toggleExpandConsole}>
+        <Button onClick={toggleExpandConsole} style={{ padding: 0 }}>
           <ImportExportIcon />
           {props.expandConsole ? 'Collapse Console' : 'Expand Console'}
           <WarningIcon style={{ display: props.warningCount ? 'block' : 'none' }} className={classes.warning} />

--- a/src/components/ConsoleComponent.js
+++ b/src/components/ConsoleComponent.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme) => ({
   consoleControls: {
     padding: theme.spacing(1),
     background: '#C0C0C0',
-    height: '1vh',
+    height: '.8vh',
     display: 'flex;',
     alignItems: 'center',
     justifyContent: 'left'
@@ -19,7 +19,10 @@ const useStyles = makeStyles((theme) => ({
   box: {
     padding: theme.spacing(2),
     color: theme.palette.common.white,
-    background: theme.palette.common.black
+    background: theme.palette.common.black,
+    height: '28vh',
+    borderBottom: '4px solid #2c4f85',
+    overflow: 'scroll'
   },
   warning: {
     color: 'khaki'
@@ -52,11 +55,11 @@ export default function Console(props) {
     <ThemeProvider theme={theme}>
       <Box
         className={classes.consoleControls}
-        style={{ borderBottom: !props.expandConsole ? '5px solid #2c4f85' : '' }}
+        style={{ borderBottom: !props.expandConsole ? '6px solid #2c4f85' : '' }}
       >
         <Button onClick={toggleExpandConsole}>
-          {props.expandConsole ? 'Collapse Console   ' : 'Expand Console   '}
           <ImportExportIcon />
+          {props.expandConsole ? 'Collapse Console' : 'Expand Console'}
           <WarningIcon style={{ display: props.warningCount ? 'block' : 'none' }} className={classes.warning} />
           {props.warningCount ? `${props.warningCount}` : ''}
           <ErrorIcon style={{ display: props.errorCount ? 'block' : 'none' }} className={classes.error} />
@@ -70,11 +73,7 @@ export default function Console(props) {
           {props.consoleMessages.length > 0 && !props.warningCount && !props.errorCount ? `Success!` : ''}
         </Button>
       </Box>
-      <Box
-        style={{ display: props.expandConsole ? 'block' : 'none', height: '28vh', borderBottom: '2px solid black' }}
-        className={classes.box}
-        overflow="scroll"
-      >
+      <Box style={{ display: props.expandConsole ? 'block' : 'none' }} className={classes.box}>
         <Typography variant="subtitle1">Console</Typography>
         {props.consoleMessages.map((message, i) => {
           return (

--- a/src/components/ConsoleComponent.js
+++ b/src/components/ConsoleComponent.js
@@ -9,7 +9,6 @@ import ErrorIcon from '@material-ui/icons/Error';
 const useStyles = makeStyles((theme) => ({
   consoleControls: {
     padding: theme.spacing(1),
-    color: '#C0C0C0',
     background: '#C0C0C0',
     height: '1vh',
     display: 'flex;',
@@ -19,8 +18,7 @@ const useStyles = makeStyles((theme) => ({
   box: {
     padding: theme.spacing(2),
     color: theme.palette.common.white,
-    background: theme.palette.common.black,
-    height: '200%'
+    background: theme.palette.common.black
   },
   warning: {
     color: 'khaki'
@@ -48,7 +46,10 @@ export default function Console(props) {
 
   return (
     <ThemeProvider theme={theme}>
-      <Box className={classes.consoleControls}>
+      <Box
+        className={classes.consoleControls}
+        style={{ borderBottom: !props.expandConsole ? '5px solid #2c4f85' : '' }}
+      >
         <Button onClick={toggleExpandConsole}>
           {props.expandConsole ? 'Collapse Console   ' : 'Expand Console   '}
           <ImportExportIcon />
@@ -59,7 +60,7 @@ export default function Console(props) {
         </Button>
       </Box>
       <Box
-        style={{ display: props.expandConsole ? 'block' : 'none', height: '30vh' }}
+        style={{ display: props.expandConsole ? 'block' : 'none', height: '28vh', borderBottom: '2px solid black' }}
         className={classes.box}
         overflow="scroll"
       >

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -10,6 +10,7 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.primary,
     background: theme.palette.background.paper,
     height: '100%',
+    boxSizing: 'border-box',
     noWrap: false
   }
 }));

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -18,7 +18,7 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(1),
     color: theme.palette.text.primary,
     background: theme.palette.background.paper,
-    height: '4vh',
+    height: '3vh',
     display: 'flex;',
     alignItems: 'center',
     justifyContent: 'center'

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -18,7 +18,6 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(1),
     color: theme.palette.text.primary,
     background: theme.palette.background.paper,
-    height: '3vh',
     display: 'flex;',
     alignItems: 'center',
     justifyContent: 'center'

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles((theme) => ({
   root: {
     background: '#2c4f85',
     position: 'static',
-    height: '50%',
+    height: '7%',
     boxShadow: '0'
   },
   title: {

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -8,7 +8,6 @@ const useStyles = makeStyles((theme) => ({
   root: {
     background: '#2c4f85',
     position: 'static',
-    height: '7%',
     boxShadow: '0'
   },
   title: {

--- a/src/tests/components/ConsoleComponent.test.js
+++ b/src/tests/components/ConsoleComponent.test.js
@@ -30,9 +30,27 @@ it('Renders with proper messages in the console', () => {
   const textElement2 = getByText(/Goodbye/i);
   const textElement3 = getByText(/How are you\?/i);
   const textElement4 = queryByText(/This shouldn't appear/i);
+  const successLabel = queryByText(/Success!/i);
 
   expect(textElement1).toBeInTheDocument();
   expect(textElement2).toBeInTheDocument();
   expect(textElement3).toBeInTheDocument();
+  expect(successLabel).toBeInTheDocument();
   expect(textElement4).not.toBeInTheDocument();
+});
+
+it('Renders error and warning labels when passed in as messages', () => {
+  const consoleMessages = ['error foo', 'error bar', 'warning foo', 'warning bar', 'info'];
+
+  const { queryByText } = render(
+    <ConsoleComponent consoleMessages={consoleMessages} errorCount={'2 Errors'} warningCount={'2 Warnings'} />,
+    container
+  );
+  const warningLabel = queryByText(/2 Warnings/i);
+  const errorLabel = queryByText(/2 Errors/i);
+  const successLabel = queryByText(/Success!/i);
+
+  expect(warningLabel).toBeInTheDocument();
+  expect(errorLabel).toBeInTheDocument();
+  expect(successLabel).not.toBeInTheDocument();
 });

--- a/src/tests/components/ConsoleComponent.test.js
+++ b/src/tests/components/ConsoleComponent.test.js
@@ -17,7 +17,7 @@ afterEach(() => {
 
 it('Renders with the appropriate label', () => {
   const { getByText } = render(<ConsoleComponent consoleMessages={[]} />, container);
-  const textElement = getByText(/Console/i);
+  const textElement = getByText('Console');
 
   expect(textElement).toBeInTheDocument();
 });


### PR DESCRIPTION
This PR address [CIMPL-683](https://standardhealthrecord.atlassian.net/browse/CIMPL-683), making the console expandable with an "Expand Console" button and also adding labels indicating how many warnings/errors resulted from the last run. I wanted the console to not make the actual editor page as a whole require any scrolling, so I've played around with some of the height values on the other components to get the height just right and not extend the content on the page to over 100% of the view screen.

