### PR TITLE
Initial GoFSH editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3240,11 +3240,6 @@
         }
       }
     },
-    "base16": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
-      "integrity": "sha1-4pf2DX7BAUp6lxo568ipjAtoHnA="
-    },
     "base64-arraybuffer-es6": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.6.0.tgz",
@@ -5159,24 +5154,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -6273,43 +6250,6 @@
         "bser": "2.1.1"
       }
     },
-    "fbemitter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
-      "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
-      "requires": {
-        "fbjs": "^0.8.4"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        }
-      }
-    },
     "fecha": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
@@ -6556,15 +6496,6 @@
             "safe-buffer": "~5.1.0"
           }
         }
-      }
-    },
-    "flux": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-3.1.3.tgz",
-      "integrity": "sha1-0jvtUVp5oi2TOrU6tK2hnQWy8Io=",
-      "requires": {
-        "fbemitter": "^2.0.0",
-        "fbjs": "^0.8.0"
       }
     },
     "fn.name": {
@@ -25192,15 +25123,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -26479,16 +26401,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
-    "lodash.curry": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA="
-    },
-    "lodash.flow": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
-      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -27051,22 +26963,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      },
-      "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        }
-      }
     },
     "node-forge": {
       "version": "0.10.0",
@@ -29003,11 +28899,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
-    "pure-color": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
-      "integrity": "sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4="
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -29150,17 +29041,6 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
-      }
-    },
-    "react-base16-styling": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.6.0.tgz",
-      "integrity": "sha1-7yFW1mz0E5aVyKFniGy2nqZgeSw=",
-      "requires": {
-        "base16": "^1.0.0",
-        "lodash.curry": "^4.0.1",
-        "lodash.flow": "^3.3.0",
-        "pure-color": "^1.2.0"
       }
     },
     "react-codemirror2": {
@@ -29419,22 +29299,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "react-json-view": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.19.1.tgz",
-      "integrity": "sha512-u5e0XDLIs9Rj43vWkKvwL8G3JzvXSl6etuS5G42a8klMohZuYFQzSN6ri+/GiBptDqlrXPTdExJVU7x9rrlXhg==",
-      "requires": {
-        "flux": "^3.1.3",
-        "react-base16-styling": "^0.6.0",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-textarea-autosize": "^6.1.0"
-      }
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-router": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
@@ -29539,14 +29403,6 @@
         "webpack-dev-server": "3.11.0",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "4.3.1"
-      }
-    },
-    "react-textarea-autosize": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-6.1.0.tgz",
-      "integrity": "sha512-F6bI1dgib6fSvG8so1HuArPUv+iVEfPliuLWusLF+gAKz0FbB4jLrWUrTAeq1afnPT2c9toEZYUdz/y1uKMy4A==",
-      "requires": {
-        "prop-types": "^15.6.0"
       }
     },
     "react-transition-group": {
@@ -31716,11 +31572,6 @@
           }
         }
       }
-    },
-    "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "react-codemirror2": "^7.2.1",
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.13.1",
-    "react-json-view": "^1.19.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.4",
     "tar-stream": "^2.1.3"

--- a/src/App.js
+++ b/src/App.js
@@ -77,9 +77,8 @@ export default function App(props) {
     setIsWaitingForOutput(isWaiting);
   }
 
-  function handleGoFSHControls(fshOutput, isWaiting) {
+  function handleGoFSHControls(fshOutput) {
     setInitialText(fshOutput);
-    setIsWaitingForOutput(isWaiting);
   }
 
   function updateInputFSHTextValue(text) {

--- a/src/App.js
+++ b/src/App.js
@@ -52,10 +52,11 @@ export default function App(props) {
   const classes = useStyles();
   const text64 = props.match.params;
   const [doRunSUSHI, setDoRunSUSHI] = useState(false);
-  const [inputText, setInputText] = useState('Edit FSH here!');
+  const [inputFSHText, setInputFSHText] = useState('Edit and view FSH here!');
+  const [inputGoFSHText, setInputGoFSHText] = useState('Edit and view FHIR Definitions here!');
   const [initialText, setInitialText] = useState('Edit FSH here!');
-  const [outputText, setOutputText] = useState('Your JSON Output Will Display Here: ');
   const [isOutputObject, setIsOutputObject] = useState(false);
+  const [isWaitingForOutput, setIsWaitingForOutput] = useState(false);
 
   useEffect(() => {
     async function waitForFSH() {
@@ -69,30 +70,48 @@ export default function App(props) {
     errorAndWarningMessages = [];
   }
 
-  function handleSUSHIControls(doRunSUSHI, sushiOutput, isObject) {
+  function handleSUSHIControls(doRunSUSHI, sushiOutput, isObject, isWaiting) {
     setDoRunSUSHI(doRunSUSHI);
-    setOutputText(sushiOutput);
+    setInputGoFSHText(sushiOutput);
     setIsOutputObject(isObject);
+    setIsWaitingForOutput(isWaiting);
   }
 
-  function updateInputTextValue(text) {
-    setInputText(text);
+  function updateInputFSHTextValue(text) {
+    setInputFSHText(text);
+  }
+
+  function updateInputGoFSHTextValue(text) {
+    setInputGoFSHText(text);
   }
 
   return (
     <div className="root">
       <TopBar />
-      <SUSHIControls onClick={handleSUSHIControls} text={inputText} resetLogMessages={resetLogMessages} />
+      <SUSHIControls
+        onClick={handleSUSHIControls}
+        fshText={inputFSHText}
+        gofshText={inputGoFSHText}
+        resetLogMessages={resetLogMessages}
+      />
       <Grid className={classes.container} container>
         <Grid className={classes.itemTop} item xs={6}>
-          <CodeMirrorComponent value={inputText} initialText={initialText} updateTextValue={updateInputTextValue} />
+          <CodeMirrorComponent
+            value={inputFSHText}
+            initialText={initialText}
+            updateTextValue={updateInputFSHTextValue}
+            mode={'fsh'}
+          />
         </Grid>
         <Grid className={classes.itemTop} item xs={6}>
           <JSONOutput
             displaySUSHI={doRunSUSHI}
-            text={outputText}
+            text={inputGoFSHText}
             isObject={isOutputObject}
+            isWaiting={isWaitingForOutput}
             errorsAndWarnings={errorAndWarningMessages}
+            updateTextValue={updateInputGoFSHTextValue}
+            setIsOutputObject={setIsOutputObject}
           />
         </Grid>
         <Grid className={classes.itemBottom} item xs={12}>

--- a/src/App.js
+++ b/src/App.js
@@ -33,14 +33,14 @@ console.log = function getMessages(message) {
 
 export async function decodeFSH(encodedFSH) {
   if (encodedFSH.text === undefined) {
-    return 'Edit FSH here!';
+    return '';
   } else {
     const promisedURL = await expandLink(encodedFSH);
 
     // Removes the encoded data from the end of the url, starting at index 38
     const sliced64 = promisedURL.long_url.slice(40);
     if (!promisedURL.long_url.includes('https://fshschool.org/FSHOnline/#/share/') || sliced64.length === 0) {
-      return 'Edit FSH here!';
+      return '';
     } else {
       const displayText = inflateSync(Buffer.from(sliced64, 'base64')).toString('utf-8');
       return displayText;
@@ -52,9 +52,9 @@ export default function App(props) {
   const classes = useStyles();
   const text64 = props.match.params;
   const [doRunSUSHI, setDoRunSUSHI] = useState(false);
-  const [inputFSHText, setInputFSHText] = useState('Edit and view FSH here!');
-  const [inputGoFSHText, setInputGoFSHText] = useState('Edit and view FHIR Definitions here!');
-  const [initialText, setInitialText] = useState('Edit FSH here!');
+  const [inputFSHText, setInputFSHText] = useState('');
+  const [inputGoFSHText, setInputGoFSHText] = useState('');
+  const [initialText, setInitialText] = useState('');
   const [isOutputObject, setIsOutputObject] = useState(false);
   const [isWaitingForOutput, setIsWaitingForOutput] = useState(false);
 
@@ -77,6 +77,11 @@ export default function App(props) {
     setIsWaitingForOutput(isWaiting);
   }
 
+  function handleGoFSHControls(fshOutput, isWaiting) {
+    setInitialText(fshOutput);
+    setIsWaitingForOutput(isWaiting);
+  }
+
   function updateInputFSHTextValue(text) {
     setInputFSHText(text);
   }
@@ -90,20 +95,22 @@ export default function App(props) {
       <TopBar />
       <SUSHIControls
         onClick={handleSUSHIControls}
+        onGoFSHClick={handleGoFSHControls}
         fshText={inputFSHText}
         gofshText={inputGoFSHText}
         resetLogMessages={resetLogMessages}
       />
       <Grid className={classes.container} container>
-        <Grid className={classes.itemTop} item xs={6}>
+        <Grid className={classes.itemTop} item xs={5}>
           <CodeMirrorComponent
             value={inputFSHText}
             initialText={initialText}
             updateTextValue={updateInputFSHTextValue}
             mode={'fsh'}
+            placeholder={'Edit FSH here!'}
           />
         </Grid>
-        <Grid className={classes.itemTop} item xs={6}>
+        <Grid className={classes.itemTop} item xs={7}>
           <JSONOutput
             displaySUSHI={doRunSUSHI}
             text={inputGoFSHText}

--- a/src/components/CodeMirrorComponent.js
+++ b/src/components/CodeMirrorComponent.js
@@ -59,6 +59,7 @@ CodeMirror.defineSimpleMode('fsh', {
 
 const useStyles = makeStyles((theme) => ({
   box: {
+    'padding-right': '1px',
     height: '100%'
   }
 }));
@@ -72,12 +73,12 @@ export default function CodeMirrorComponent(props) {
   }
 
   return (
-    <Box className={classes.box} borderTop={1}>
+    <Box className={classes.box}>
       <ReactCodeMirror
         className="react-codemirror2"
         value={props.initialText}
         options={{
-          mode: 'fsh',
+          mode: props.mode,
           theme: 'material',
           lineNumbers: true
         }}

--- a/src/components/CodeMirrorComponent.js
+++ b/src/components/CodeMirrorComponent.js
@@ -7,6 +7,7 @@ import '../style/CodeMirrorComponent.css';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
 require('codemirror/addon/mode/simple');
+require('codemirror/addon/display/placeholder');
 require('codemirror/mode/xml/xml');
 require('codemirror/mode/javascript/javascript');
 
@@ -80,6 +81,7 @@ export default function CodeMirrorComponent(props) {
         options={{
           mode: props.mode,
           theme: 'material',
+          placeholder: props.placeholder,
           lineNumbers: true
         }}
         onChange={(editor, data, value) => {

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -40,7 +40,7 @@ export default function JSONOutput(props) {
   const classes = useStyles();
   const [fhirDefinitions, setFhirDefinitions] = useState([]);
   const { setIsOutputObject } = props;
-  const [currentDef, setCurrentDef] = useState(0); // JULIA will update with file explorer
+  const [currentDef, setCurrentDef] = useState(0);
 
   useEffect(() => {
     // This case represents when we receive a new Package from SUSHI

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -38,6 +38,7 @@ const getIterablePackage = (defsPackage) => {
 
 export default function JSONOutput(props) {
   const classes = useStyles();
+  const [initialText, setInitialText] = useState('');
   const [fhirDefinitions, setFhirDefinitions] = useState([]);
   const { setIsOutputObject } = props;
   const [currentDef, setCurrentDef] = useState(0);
@@ -48,9 +49,14 @@ export default function JSONOutput(props) {
       // Indicate that we no longer have new data we need to load so we don't come back here too early
       setIsOutputObject(false);
       const packageJSON = JSON.parse(props.text);
-      setFhirDefinitions(getIterablePackage(packageJSON));
+      const iterablePackage = getIterablePackage(packageJSON);
+      setFhirDefinitions(iterablePackage);
+      setInitialText(iterablePackage.length > 0 ? JSON.stringify(iterablePackage[0], null, 2) : '');
+    } else if (props.isWaiting) {
+      // Set Loading... text
+      setInitialText(props.text);
     }
-  }, [props.displaySUSHI, props.text, props.isObject, setIsOutputObject]);
+  }, [props.displaySUSHI, props.text, props.isObject, props.isWaiting, setIsOutputObject]);
 
   const updateTextValue = (text) => {
     // We're waiting for a new package to load, so we don't want the editor to update yet
@@ -88,7 +94,7 @@ export default function JSONOutput(props) {
           <Grid item xs={9} style={{ height: '75vh' }}>
             <CodeMirrorComponent
               value={displayValue}
-              initialText={displayValue}
+              initialText={initialText}
               updateTextValue={updateTextValue}
               mode={'application/json'}
               placeholder={'Edit and view FHIR Definitions here!'}

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -54,10 +54,10 @@ export default function JSONOutput(props) {
 
   const updateTextValue = (text) => {
     // We're waiting for a new package to load, so we don't want the editor to update yet
-    if (props.isWaiting || !props.displaySUSHI) return;
+    if (props.isWaiting) return;
 
     // Update the definition we're currently editing
-    const updatedDefs = fhirDefinitions;
+    const updatedDefs = [...fhirDefinitions];
     try {
       updatedDefs[currentDef] = JSON.parse(text);
     } catch (e) {

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Box, Grid } from '@material-ui/core';
+import { Box, Grid, List, ListItem } from '@material-ui/core';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import CodeMirrorComponent from './CodeMirrorComponent';
 
@@ -10,6 +10,13 @@ const useStyles = makeStyles((theme) => ({
     background: theme.palette.background.paper,
     height: '100%',
     noWrap: false
+  },
+  list: {
+    padding: 0
+  },
+  listItem: {
+    padding: 0,
+    margin: 0
   }
 }));
 
@@ -47,7 +54,7 @@ export default function JSONOutput(props) {
 
   const updateTextValue = (text) => {
     // We're waiting for a new package to load, so we don't want the editor to update yet
-    if (props.isWaiting) return;
+    if (props.isWaiting || !props.displaySUSHI) return;
 
     // Update the definition we're currently editing
     const updatedDefs = fhirDefinitions;
@@ -60,8 +67,19 @@ export default function JSONOutput(props) {
     props.updateTextValue(updatedDefs);
   };
 
-  // TODO: need somewhere to display error content?
-  const displayValue = fhirDefinitions.length ? JSON.stringify(fhirDefinitions[currentDef], null, 2) : props.text;
+  const renderFileTreeView = () => {
+    return (
+      <List component="nav" className={classes.list}>
+        {fhirDefinitions.map((a, i) => (
+          <ListItem button key={i} className={classes.listItem} onClick={() => setCurrentDef(i)}>
+            {`${a.resourceType}/${a.id}`}
+          </ListItem>
+        ))}
+      </List>
+    );
+  };
+
+  const displayValue = fhirDefinitions.length > 0 ? JSON.stringify(fhirDefinitions[currentDef], null, 2) : props.text;
 
   return (
     <ThemeProvider theme={theme}>
@@ -73,12 +91,11 @@ export default function JSONOutput(props) {
               initialText={displayValue}
               updateTextValue={updateTextValue}
               mode={'application/json'}
+              placeholder={'Edit and view FHIR Definitions here!'}
             />
           </Grid>
           <Grid item xs={3}>
-            {fhirDefinitions.map((a, i) => (
-              <button key={i} onClick={() => setCurrentDef(i)}>{`${a.resourceType}/${a.id}`}</button>
-            ))}
+            {renderFileTreeView()}
           </Grid>
         </Grid>
       </Box>

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -1,12 +1,11 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Box, Typography } from '@material-ui/core';
-import ReactJson from 'react-json-view';
+import { Box, Grid } from '@material-ui/core';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import CodeMirrorComponent from './CodeMirrorComponent';
 
 const useStyles = makeStyles((theme) => ({
   box: {
-    padding: theme.spacing(0.2, 2),
     color: theme.palette.text.primary,
     background: theme.palette.background.paper,
     height: '100%',
@@ -20,50 +19,69 @@ const theme = createMuiTheme({
   }
 });
 
-const renderErrorAndWarningContent = (errorsAndWarnings = []) => {
-  if (errorsAndWarnings.length > 0) {
-    return (
-      <ThemeProvider theme={theme}>
-        <span>
-          <Typography variant="subtitle2">Errors and Warnings</Typography>
-          {errorsAndWarnings.map((message, i) => (
-            <pre key={i}>{message}</pre>
-          ))}
-        </span>
-      </ThemeProvider>
-    );
-  }
-  return;
-};
-
-const renderDisplayContent = (displaySUSHI, text, isObject) => {
-  if (displaySUSHI && text && isObject) {
-    const packageJSON = JSON.parse(text);
-    return (
-      <ThemeProvider theme={theme}>
-        <span>
-          <Typography variant="subtitle2">Results</Typography>
-          <ReactJson src={packageJSON} displayDataTypes={false} collapsed={false} name={false} />
-        </span>
-      </ThemeProvider>
-    );
-  } else if (displaySUSHI && text) {
-    return <pre>{text}</pre>;
-  }
-  return '';
+const getIterablePackage = (defsPackage) => {
+  return [
+    ...defsPackage.profiles,
+    ...defsPackage.extensions,
+    ...defsPackage.instances,
+    ...defsPackage.valueSets,
+    ...defsPackage.codeSystems
+  ];
 };
 
 export default function JSONOutput(props) {
   const classes = useStyles();
-  const errorAndWarningContent = renderErrorAndWarningContent(props.errorsAndWarnings);
-  const displayContent = renderDisplayContent(props.displaySUSHI, props.text, props.isObject);
+  const [fhirDefinitions, setFhirDefinitions] = useState([]);
+  const { setIsOutputObject } = props;
+  const [currentDef, setCurrentDef] = useState(0); // JULIA will update with file explorer
+
+  useEffect(() => {
+    // This case represents when we receive a new Package from SUSHI
+    if (props.displaySUSHI && props.text && props.isObject) {
+      // Indicate that we no longer have new data we need to load so we don't come back here too early
+      setIsOutputObject(false);
+      const packageJSON = JSON.parse(props.text);
+      setFhirDefinitions(getIterablePackage(packageJSON));
+      console.log(getIterablePackage(packageJSON));
+    }
+  }, [props.displaySUSHI, props.text, props.isObject, setIsOutputObject]);
+
+  const updateTextValue = (text) => {
+    // We're waiting for a new package to load, so we don't want the editor to update yet
+    if (props.isWaiting) return;
+
+    // Update the definition we're currently editing
+    const updatedDefs = fhirDefinitions;
+    try {
+      updatedDefs[currentDef] = JSON.parse(text);
+    } catch (e) {
+      // Invalid JSON typed. Decide if/how to alert.
+    }
+    setFhirDefinitions(updatedDefs);
+    props.updateTextValue(updatedDefs);
+  };
+
+  // TODO: need somewhere to display error content?
+  const displayValue = fhirDefinitions.length ? JSON.stringify(fhirDefinitions[currentDef], null, 2) : props.text;
 
   return (
     <ThemeProvider theme={theme}>
       <Box className={classes.box} border={1} overflow="scroll">
-        <Typography variant="subtitle1">SUSHI Output</Typography>
-        {errorAndWarningContent}
-        {displayContent}
+        <Grid container>
+          <Grid item xs={9} style={{ height: '75vh' }}>
+            <CodeMirrorComponent
+              value={displayValue}
+              initialText={displayValue}
+              updateTextValue={updateTextValue}
+              mode={'application/json'}
+            />
+          </Grid>
+          <Grid item xs={3}>
+            {fhirDefinitions.map((a, i) => (
+              <button key={i} onClick={() => setCurrentDef(i)}>{`${a.resourceType}/${a.id}`}</button>
+            ))}
+          </Grid>
+        </Grid>
       </Box>
     </ThemeProvider>
   );

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -42,7 +42,6 @@ export default function JSONOutput(props) {
       setIsOutputObject(false);
       const packageJSON = JSON.parse(props.text);
       setFhirDefinitions(getIterablePackage(packageJSON));
-      console.log(getIterablePackage(packageJSON));
     }
   }, [props.displaySUSHI, props.text, props.isObject, setIsOutputObject]);
 

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -186,7 +186,7 @@ export default function SUSHIControls(props) {
         <Button className={classes.secondaryButton} onClick={handleOpenShare}>
           Share
         </Button>
-        <Button className={classes.button} onClick={handleGoFSHClick}>
+        <Button className={classes.button} onClick={handleGoFSHClick} testid="GoFSH-button">
           Run GoFSH
         </Button>
         <Dialog open={openConfig} onClose={handleCloseConfig} aria-labelledby="form-dialog-title">

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -89,7 +89,7 @@ export default function SUSHIControls(props) {
   };
 
   const handleOpenShare = async () => {
-    const encoded = deflateSync(props.text).toString('base64');
+    const encoded = deflateSync(props.fshText).toString('base64');
     const longLink = `https://fshschool.org/FSHOnline/#/share/${encoded}`;
     const bitlyLink = await generateLink(longLink);
     if (bitlyLink.errorNeeded === true) {
@@ -139,11 +139,11 @@ export default function SUSHIControls(props) {
   //Sets the doRunSUSHI to true
   async function handleRunClick() {
     props.resetLogMessages();
-    props.onClick(true, 'Loading...', false);
+    props.onClick(true, 'Loading...', false, true);
     let isObject = true;
     const dependencyArr = sliceDependency(dependencies);
     const config = { canonical, version, FSHOnly: true, fhirVersion: ['4.0.1'] };
-    const outPackage = await runSUSHI(props.text, config, dependencyArr);
+    const outPackage = await runSUSHI(props.fshText, config, dependencyArr);
     let jsonOutput = JSON.stringify(outPackage, replacer, 2);
     if (outPackage && outPackage.codeSystems) {
       if (
@@ -161,69 +161,15 @@ export default function SUSHIControls(props) {
       jsonOutput = '';
     }
 
-    props.onClick(true, jsonOutput, isObject);
+    props.onClick(true, jsonOutput, isObject, false);
   }
 
   async function handleGoFSHClick() {
-    const exInput = {
-      resourceType: 'Observation',
-      id: 'example',
-      status: 'final',
-      code: {
-        coding: [
-          {
-            code: 'bar',
-            system: 'http://foo.org'
-          }
-        ]
-      },
-      subject: {
-        reference: 'Patient/example'
-      }
-    };
-    const exPatient = {
-      resourceType: 'Patient',
-      id: 'MyPatient',
-      name: [
-        {
-          family: 'Smith',
-          given: ['Jane']
-        }
-      ],
-      maritalStatus: {
-        coding: [
-          {
-            code: 'M',
-            display: 'Married'
-          }
-        ]
-      }
-    };
-    const exIG = {
-      resourceType: 'ImplementationGuide',
-      url: 'http://example.org/tests/ImplementationGuide/bigger.ig',
-      fhirVersion: ['4.0.1'],
-      id: 'bigger.ig',
-      name: 'BiggerImplementationGuideForTesting',
-      status: 'active',
-      version: '0.12',
-      dependsOn: [
-        {
-          uri: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core',
-          packageId: 'hl7.fhir.us.core',
-          version: '3.1.0'
-        },
-        {
-          uri: 'http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode',
-          packageId: 'hl7.fhir.us.mcode',
-          version: '1.0.0'
-        }
-      ]
-    };
+    const gofshInputStrings = [];
+    props.gofshText.forEach((def) => gofshInputStrings.push(JSON.stringify(def)));
     const parsedDependencies = dependencies === '' ? [] : dependencies.split(',');
     const options = { dependencies: parsedDependencies };
-    //eslint-disable-next-line no-unused-vars
-    const fsh = await runGoFSH([JSON.stringify(exInput), JSON.stringify(exPatient), JSON.stringify(exIG)], options);
+    const fsh = await runGoFSH(gofshInputStrings, options); // eslint-disable-line no-unused-vars
   }
 
   return (

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -165,11 +165,13 @@ export default function SUSHIControls(props) {
   }
 
   async function handleGoFSHClick() {
+    props.onGoFSHClick('Loading...', true);
     const gofshInputStrings = [];
     props.gofshText.forEach((def) => gofshInputStrings.push(JSON.stringify(def)));
     const parsedDependencies = dependencies === '' ? [] : dependencies.split(',');
     const options = { dependencies: parsedDependencies };
-    const fsh = await runGoFSH(gofshInputStrings, options); // eslint-disable-line no-unused-vars
+    const fsh = await runGoFSH(gofshInputStrings, options);
+    props.onGoFSHClick(fsh, false);
   }
 
   return (

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -165,13 +165,13 @@ export default function SUSHIControls(props) {
   }
 
   async function handleGoFSHClick() {
-    props.onGoFSHClick('Loading...', true);
+    props.onGoFSHClick('Loading...');
     const gofshInputStrings = [];
     props.gofshText.forEach((def) => gofshInputStrings.push(JSON.stringify(def)));
     const parsedDependencies = dependencies === '' ? [] : dependencies.split(',');
     const options = { dependencies: parsedDependencies };
     const fsh = await runGoFSH(gofshInputStrings, options);
-    props.onGoFSHClick(fsh, false);
+    props.onGoFSHClick(fsh);
   }
 
   return (

--- a/src/style/CodeMirrorComponent.css
+++ b/src/style/CodeMirrorComponent.css
@@ -4,3 +4,6 @@
 .react-codemirror2 > .CodeMirror {
   height: 100%;
 }
+.react-codemirror2 > .CodeMirror pre.CodeMirror-placeholder {
+  color: #546e7a;
+}

--- a/src/tests/components/JSONOutput.test.js
+++ b/src/tests/components/JSONOutput.test.js
@@ -24,20 +24,17 @@ afterEach(() => {
   container = null;
 });
 
-it('Renders with the default text if displaySUSHI is false', () => {
+it('Renders with the default text if displaySUSHI is false, isObject is false, and no text', () => {
   // Initial case, nothing from SUSHI is displayed
   const { getByText } = render(
-    <JSONOutput displaySUSHI={false} text={'Hello World'} errorsAndWarnings={[]} />,
+    <JSONOutput displaySUSHI={false} isObject={false} text={''} errorsAndWarnings={[]} />,
     container
   );
 
   // Because the editor is in JSON mode, the text is split up differently than the fsh mode
-  const headerElement = getByText(
-    (content, element) => element.tagName.toLowerCase() === 'span' && content.startsWith('Hello')
-  );
+  const placeholderText = getByText('Edit and view FHIR Definitions here!');
 
-  expect(headerElement).toBeInTheDocument();
-  expect(headerElement.parentNode.textContent).toEqual('Hello World');
+  expect(placeholderText).toBeInTheDocument();
 });
 
 it('Renders with the proper text and updates with proper text when not an object', () => {

--- a/src/tests/components/JSONOutput.test.js
+++ b/src/tests/components/JSONOutput.test.js
@@ -89,23 +89,3 @@ it.skip('Renders with the first profile when text is an object (SUSHI Package)',
   expect(resultsElement).toBeInTheDocument(); // isObject is true so results are printed
   expect(resultsElement.parentNode.text).toEqual();
 });
-
-// TODO: determine if/how we display error content somewhere
-it.skip('Renders error messages if present', () => {
-  const { getByText } = render(
-    <JSONOutput
-      displaySUSHI={true}
-      isObject={false}
-      text={'Hello World'}
-      errorsAndWarnings={['error Unexpected input', 'error Something else wrong']}
-    />,
-    container
-  );
-  const errorHeading = getByText(/Errors/);
-  const firstError = getByText(/Unexpected input/);
-  const secondError = getByText(/Something else wrong/);
-
-  expect(errorHeading).toBeInTheDocument();
-  expect(firstError).toBeInTheDocument();
-  expect(secondError).toBeInTheDocument();
-});

--- a/src/tests/components/JSONOutput.test.js
+++ b/src/tests/components/JSONOutput.test.js
@@ -3,6 +3,15 @@ import { render } from '@testing-library/react';
 import { unmountComponentAtNode } from 'react-dom';
 import JSONOutput from '../../components/JSONOutput';
 
+beforeAll(() => {
+  document.body.createTextRange = () => {
+    return {
+      getBoundingClientRect: () => ({ right: 0 }),
+      getClientRects: () => ({ left: 0 })
+    };
+  };
+});
+
 let container = null;
 beforeEach(() => {
   container = document.createElement('div');
@@ -15,48 +24,74 @@ afterEach(() => {
   container = null;
 });
 
-it('Renders with the default heading if displaySUSHI is false', () => {
+it('Renders with the default text if displaySUSHI is false', () => {
   // Initial case, nothing from SUSHI is displayed
-  const { getByText, queryByText } = render(
+  const { getByText } = render(
     <JSONOutput displaySUSHI={false} text={'Hello World'} errorsAndWarnings={[]} />,
     container
   );
-  const headerElement = getByText(/SUSHI Output/i);
-  const resultsElement = queryByText(/Results/i);
-  const errorsElement = queryByText(/Errors/i);
+
+  // Because the editor is in JSON mode, the text is split up differently than the fsh mode
+  const headerElement = getByText(
+    (content, element) => element.tagName.toLowerCase() === 'span' && content.startsWith('Hello')
+  );
 
   expect(headerElement).toBeInTheDocument();
-  expect(resultsElement).not.toBeInTheDocument();
-  expect(errorsElement).not.toBeInTheDocument();
+  expect(headerElement.parentNode.textContent).toEqual('Hello World');
 });
 
-it('Renders with the proper heading and updates with proper text when not an object', () => {
-  const { getByText, queryByText } = render(
-    <JSONOutput displaySUSHI={true} text={'Hello World'} isObject={false} errorsAndWarnings={[]} />,
+it('Renders with the proper text and updates with proper text when not an object', () => {
+  const { getByText } = render(
+    <JSONOutput displaySUSHI={true} text={'Loading...'} isObject={false} errorsAndWarnings={[]} isWaiting={true} />,
     container
   );
-  const resultsElement = queryByText(/Results/i);
-  const errorsElement = queryByText(/Errors/i);
-  const textElement = getByText(/Hello World/i);
+  const textElement = getByText(
+    (content, element) => element.tagName.toLowerCase() === 'span' && content.startsWith('Loading')
+  );
 
-  expect(resultsElement).not.toBeInTheDocument();
-  expect(errorsElement).not.toBeInTheDocument();
   expect(textElement).toBeInTheDocument(); // Mimics the 'loading...' case
+  expect(textElement.parentNode.textContent).toEqual('Loading...');
 });
 
-it('Renders with the proper headings when text is an object (SUSHI Package)', () => {
-  const { getByText, queryByText } = render(
-    <JSONOutput displaySUSHI={true} text={JSON.stringify({ profiles: [] })} isObject={true} errorsAndWarnings={[]} />,
+// TODO: CodeMirrorComponent doesn't get the package text properly - not sure why
+it.skip('Renders with the first profile when text is an object (SUSHI Package)', async () => {
+  const { getByText } = render(
+    <JSONOutput
+      displaySUSHI={true}
+      text={JSON.stringify(
+        {
+          profiles: [
+            {
+              resourceType: 'StructureDefinition',
+              id: 'A'
+            }
+          ],
+          extensions: [],
+          instances: [],
+          valueSets: [],
+          codeSystems: []
+        },
+        null,
+        2
+      )}
+      isObject={true}
+      isWaiting={true}
+      errorsAndWarnings={[]}
+      updateTextValue={(text) => text}
+      setIsOutputObject={() => {}}
+    />,
     container
   );
-  const resultsElement = getByText(/Results/i);
-  const errorsElement = queryByText(/Errors/i);
 
+  const resultsElement = getByText(
+    (content, element) => element.tagName.toLowerCase() === 'span' && content.startsWith('resourceType')
+  );
   expect(resultsElement).toBeInTheDocument(); // isObject is true so results are printed
-  expect(errorsElement).not.toBeInTheDocument(); // No errors
+  expect(resultsElement.parentNode.text).toEqual();
 });
 
-it('Renders error messages if present', () => {
+// TODO: determine if/how we display error content somewhere
+it.skip('Renders error messages if present', () => {
   const { getByText } = render(
     <JSONOutput
       displaySUSHI={true}

--- a/src/tests/components/SUSHIControls.test.js
+++ b/src/tests/components/SUSHIControls.test.js
@@ -101,6 +101,27 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits a good 
   });
 });
 
+it('calls GoFSH function and returns FSH', async () => {
+  const simpleFsh = ['Instance: MyPatient', 'InstanceOf: Patient', 'Usage: #example', '* gender = #female'].join('\n');
+  const onGoFSHClick = jest.fn();
+  const runGoFSHSpy = jest.spyOn(runSUSHI, 'runGoFSH').mockReset().mockResolvedValue(simpleFsh);
+
+  act(() => {
+    render(<SUSHIControls onGoFSHClick={onGoFSHClick} gofshText={[]} />, container);
+  });
+  const button = document.querySelector('[testid=GoFSH-button]');
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
+  await wait(() => {
+    expect(runGoFSHSpy).toHaveBeenCalled();
+    expect(onGoFSHClick).toHaveBeenCalledTimes(2);
+    expect(onGoFSHClick).toHaveBeenCalledWith('Loading...', true);
+    expect(onGoFSHClick).toHaveBeenCalledWith(simpleFsh, false);
+  });
+});
+
 it('uses user provided canonical when calling runSUSHI', async () => {
   const onClick = jest.fn();
   const resetLogMessages = jest.fn();

--- a/src/tests/components/SUSHIControls.test.js
+++ b/src/tests/components/SUSHIControls.test.js
@@ -117,8 +117,8 @@ it('calls GoFSH function and returns FSH', async () => {
   await wait(() => {
     expect(runGoFSHSpy).toHaveBeenCalled();
     expect(onGoFSHClick).toHaveBeenCalledTimes(2);
-    expect(onGoFSHClick).toHaveBeenCalledWith('Loading...', true);
-    expect(onGoFSHClick).toHaveBeenCalledWith(simpleFsh, false);
+    expect(onGoFSHClick).toHaveBeenCalledWith('Loading...');
+    expect(onGoFSHClick).toHaveBeenCalledWith(simpleFsh);
   });
 });
 

--- a/src/tests/components/SUSHIControls.test.js
+++ b/src/tests/components/SUSHIControls.test.js
@@ -52,8 +52,8 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits a bad p
     expect(resetLogMessages).toHaveBeenCalledTimes(1);
     expect(runSUSHISpy).toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledTimes(2);
-    expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false);
-    expect(onClick).toHaveBeenCalledWith(true, '', false);
+    expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false, true);
+    expect(onClick).toHaveBeenCalledWith(true, '', false, false);
   });
 });
 
@@ -74,8 +74,8 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits an empt
     expect(resetLogMessages).toHaveBeenCalledTimes(1);
     expect(runSUSHISpy).toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledTimes(2);
-    expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false);
-    expect(onClick).toHaveBeenCalledWith(true, '', false);
+    expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false, true);
+    expect(onClick).toHaveBeenCalledWith(true, '', false, false);
   });
 });
 
@@ -96,8 +96,8 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits a good 
     expect(resetLogMessages).toHaveBeenCalledTimes(1);
     expect(runSUSHISpy).toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledTimes(2);
-    expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false);
-    expect(onClick).toHaveBeenCalledWith(true, JSON.stringify(goodSUSHIPackage, null, 2), true);
+    expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false, true);
+    expect(onClick).toHaveBeenCalledWith(true, JSON.stringify(goodSUSHIPackage, null, 2), true, false);
   });
 });
 
@@ -211,7 +211,7 @@ it('copies link to clipboard on button click', async () => {
     .mockResolvedValue({ link: 'success', errorNeeded: false });
 
   const { getByText } = render(
-    <SUSHIControls onClick={onClick} text={'Edit FSH Here'} resetLogMessages={resetLogMessages} />,
+    <SUSHIControls onClick={onClick} fshText={'Edit FSH Here'} resetLogMessages={resetLogMessages} />,
     container
   );
 
@@ -236,7 +236,7 @@ it('generates link when share button is clicked', async () => {
     .mockResolvedValue({ link: 'success', errorNeeded: false });
 
   const { getByText } = render(
-    <SUSHIControls onClick={onClick} text={'Edit FSH Here'} resetLogMessages={resetLogMessages} />,
+    <SUSHIControls onClick={onClick} fshText={'Edit FSH Here'} resetLogMessages={resetLogMessages} />,
     container
   );
 
@@ -258,7 +258,7 @@ it('shows an error when the FSH file is too long to share', async () => {
     .mockResolvedValue({ link: undefined, errorNeeded: true });
 
   const { getByText } = render(
-    <SUSHIControls onClick={onClick} text={'Edit FSH Here'} resetLogMessages={resetLogMessages} />,
+    <SUSHIControls onClick={onClick} fshText={'Edit FSH Here'} resetLogMessages={resetLogMessages} />,
     container
   );
   act(() => {


### PR DESCRIPTION
This PR replaces the current RHS of FSH Online with an editor that can be used to for GoFSH inputs.

Currently, when you type in FSH on the LHS and run SUSHI, the editor on the RHS will populate with the first definition in the package. There is a very simple file navigator on the right that will let you switch to any other definitions that were in the package. Clicking a different definition should update the text in the editor, but the majority of the styling and organization for the file list will be part of a different PR (because it is a separate task). Additionally, you can edit the text in the RHS editor and then run GoFSH. The LHS FSH editor should populate with the resulting FSH.

This PR also updates the editor to use a placeholder plugin to display the initial text in the editors. It also removes the "Errors and Warnings" summary that currently displays on the RHS of FSH Online. There wasn't an obvious place I could think to display those, and the changes Julian made to the console should make it more obvious when there are errors or warnings, so I took them out of the RHS.

Note: There are still some components and files that have very "SUSHI" specific names, but since changing those would make the diffs difficult to understand, I'm planning on updating that in it's own PR at some point.
Another note: There is one test skipped that was supposed to be for testing that text is populated to the JSON editor on the RHS. However, the text that gets populated in the test is not right and I haven't been able to figure the right way to test that, but I thought it was more important to put up this PR. 