### PR TITLE
Updated JSON Definition File Tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1525,6 +1525,14 @@
         "react-transition-group": "^4.4.0"
       }
     },
+    "@material-ui/icons": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
+      "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material-ui/core": "^4.10.2",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/src/App.js
+++ b/src/App.js
@@ -53,7 +53,7 @@ export default function App(props) {
   const text64 = props.match.params;
   const [doRunSUSHI, setDoRunSUSHI] = useState(false);
   const [inputFSHText, setInputFSHText] = useState('');
-  const [inputGoFSHText, setInputGoFSHText] = useState('');
+  const [inputGoFSHText, setInputGoFSHText] = useState(['']);
   const [initialText, setInitialText] = useState('');
   const [isOutputObject, setIsOutputObject] = useState(false);
   const [isWaitingForOutput, setIsWaitingForOutput] = useState(false);
@@ -106,7 +106,7 @@ export default function App(props) {
             initialText={initialText}
             updateTextValue={updateInputFSHTextValue}
             mode={'fsh'}
-            placeholder={'Edit FSH here!'}
+            placeholder={isWaitingForOutput ? 'Loading...' : 'Edit FSH here!'}
           />
         </Grid>
         <Grid className={classes.itemTop} item xs={7}>

--- a/src/App.js
+++ b/src/App.js
@@ -56,7 +56,8 @@ export default function App(props) {
   const [inputGoFSHText, setInputGoFSHText] = useState(['']);
   const [initialText, setInitialText] = useState('');
   const [isOutputObject, setIsOutputObject] = useState(false);
-  const [isWaitingForOutput, setIsWaitingForOutput] = useState(false);
+  const [isWaitingForFHIROutput, setIsWaitingForFHIROutput] = useState(false);
+  const [isWaitingForFSHOutput, setIsWaitingForFSHOutput] = useState(false);
 
   useEffect(() => {
     async function waitForFSH() {
@@ -74,10 +75,11 @@ export default function App(props) {
     setDoRunSUSHI(doRunSUSHI);
     setInputGoFSHText(sushiOutput);
     setIsOutputObject(isObject);
-    setIsWaitingForOutput(isWaiting);
+    setIsWaitingForFHIROutput(isWaiting);
   }
 
-  function handleGoFSHControls(fshOutput) {
+  function handleGoFSHControls(fshOutput, isWaiting) {
+    setIsWaitingForFSHOutput(isWaiting);
     setInitialText(fshOutput);
   }
 
@@ -106,7 +108,7 @@ export default function App(props) {
             initialText={initialText}
             updateTextValue={updateInputFSHTextValue}
             mode={'fsh'}
-            placeholder={isWaitingForOutput ? 'Loading...' : 'Edit FSH here!'}
+            placeholder={isWaitingForFSHOutput ? 'Loading...' : 'Edit FSH here!'}
           />
         </Grid>
         <Grid className={classes.itemTop} item xs={7}>
@@ -114,7 +116,7 @@ export default function App(props) {
             displaySUSHI={doRunSUSHI}
             text={inputGoFSHText}
             isObject={isOutputObject}
-            isWaiting={isWaitingForOutput}
+            isWaiting={isWaitingForFHIROutput}
             errorsAndWarnings={errorAndWarningMessages}
             updateTextValue={updateInputGoFSHTextValue}
             setIsOutputObject={setIsOutputObject}

--- a/src/App.js
+++ b/src/App.js
@@ -73,14 +73,14 @@ export default function App(props) {
 
   function handleSUSHIControls(doRunSUSHI, sushiOutput, isObject, isWaiting) {
     setDoRunSUSHI(doRunSUSHI);
-    setInputGoFSHText(sushiOutput);
+    setInputGoFSHText(sushiOutput); // JSONOutput component handles resetting initial text, so don't reset here
     setIsOutputObject(isObject);
     setIsWaitingForFHIROutput(isWaiting);
   }
 
   function handleGoFSHControls(fshOutput, isWaiting) {
     setIsWaitingForFSHOutput(isWaiting);
-    setInitialText(fshOutput);
+    setInitialText(fshOutput === '' ? null : fshOutput); // Reset initial text to null if empty in order to display placeholder text
   }
 
   function updateInputFSHTextValue(text) {

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -80,8 +80,11 @@ export default function JSONOutput(props) {
       const iterablePackage = getIterablePackage(packageJSON);
       setFhirDefinitions(iterablePackage);
       setInitialText(iterablePackage.length > 0 ? iterablePackage[0].def : '');
+    } else if (props.isWaiting) {
+      setInitialText(null); // Reset the text to null when loading to reset the editor and display placeholder text
+      setFhirDefinitions([]); // Reset FHIR definitions to clear out file tree
     }
-  }, [props.displaySUSHI, props.text, props.isObject, setIsOutputObject]);
+  }, [props.displaySUSHI, props.text, props.isObject, props.isWaiting, setIsOutputObject]);
 
   const updateTextValue = (text) => {
     // We're waiting for a new package to load, so we don't want the editor to update yet

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -152,7 +152,7 @@ export default function JSONOutput(props) {
             {key}
             {grouped[key]
               .sort((a, b) =>
-                a.id.toLowerCase() < b.id.toLowerCase() ? -1 : a.id.toLowerCase() > b.id.toLowerCase() ? 1 : 0
+                a.id?.toLowerCase() < b.id?.toLowerCase() ? -1 : a.id?.toLowerCase() > b.id?.toLowerCase() ? 1 : 0
               ) // Sort ids alphabetically
               .map((def, i) => {
                 const currentIndex = fhirDefinitions.indexOf(def);
@@ -179,7 +179,7 @@ export default function JSONOutput(props) {
                     ) : (
                       <span className={classes.blankIcon} />
                     )}
-                    {def.id}
+                    {def.id || 'Untitled'}
                   </ListItem>
                 );
               })}

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { groupBy } from 'lodash';
 import { makeStyles } from '@material-ui/core/styles';
 import { Box, Grid, List, ListItem } from '@material-ui/core';
-import { CheckCircleOutline, HighlightOff } from '@material-ui/icons';
+import { HighlightOff } from '@material-ui/icons';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import CodeMirrorComponent from './CodeMirrorComponent';
 
@@ -80,11 +80,8 @@ export default function JSONOutput(props) {
       const iterablePackage = getIterablePackage(packageJSON);
       setFhirDefinitions(iterablePackage);
       setInitialText(iterablePackage.length > 0 ? iterablePackage[0].def : '');
-    } else if (props.isWaiting) {
-      // Set Loading... text
-      setInitialText(props.text);
     }
-  }, [props.displaySUSHI, props.text, props.isObject, props.isWaiting, setIsOutputObject]);
+  }, [props.displaySUSHI, props.text, props.isObject, setIsOutputObject]);
 
   const updateTextValue = (text) => {
     // We're waiting for a new package to load, so we don't want the editor to update yet
@@ -200,7 +197,7 @@ export default function JSONOutput(props) {
               initialText={initialText}
               updateTextValue={updateTextValue}
               mode={'application/json'}
-              placeholder={'Edit and view FHIR Definitions here!'}
+              placeholder={props.isWaiting ? 'Loading...' : 'Edit and view FHIR Definitions here!'}
             />
           </Grid>
           <Grid item xs={3} style={{ overflow: 'scroll', height: '75vh' }}>

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -38,6 +38,9 @@ const useStyles = makeStyles((theme) => ({
   listIcon: {
     fontSize: '13px',
     padding: '3px'
+  },
+  blankIcon: {
+    width: '19px' // width of icon
   }
 }));
 
@@ -174,7 +177,7 @@ export default function JSONOutput(props) {
                     {defsWithErrors.includes(currentIndex) ? (
                       <HighlightOff className={classes.listIcon} />
                     ) : (
-                      <CheckCircleOutline className={classes.listIcon} />
+                      <span className={classes.blankIcon} />
                     )}
                     {def.id}
                   </ListItem>

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -154,11 +154,11 @@ export default function SUSHIControls(props) {
         !outPackage.valueSets.length
       ) {
         isObject = false;
-        jsonOutput = '';
+        jsonOutput = [''];
       }
     } else {
       isObject = false;
-      jsonOutput = '';
+      jsonOutput = [''];
     }
 
     props.onClick(true, jsonOutput, isObject, false);
@@ -166,8 +166,7 @@ export default function SUSHIControls(props) {
 
   async function handleGoFSHClick() {
     props.onGoFSHClick('Loading...');
-    const gofshInputStrings = [];
-    props.gofshText.forEach((def) => gofshInputStrings.push(JSON.stringify(def)));
+    const gofshInputStrings = props.gofshText.map((def) => def.def);
     const parsedDependencies = dependencies === '' ? [] : dependencies.split(',');
     const options = { dependencies: parsedDependencies };
     const fsh = await runGoFSH(gofshInputStrings, options);

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -139,7 +139,7 @@ export default function SUSHIControls(props) {
   //Sets the doRunSUSHI to true
   async function handleRunClick() {
     props.resetLogMessages();
-    props.onClick(true, 'Loading...', false, true);
+    props.onClick(true, [''], false, true);
     let isObject = true;
     const dependencyArr = sliceDependency(dependencies);
     const config = { canonical, version, FSHOnly: true, fhirVersion: ['4.0.1'] };
@@ -165,12 +165,12 @@ export default function SUSHIControls(props) {
   }
 
   async function handleGoFSHClick() {
-    props.onGoFSHClick('Loading...');
+    props.onGoFSHClick('', true);
     const gofshInputStrings = props.gofshText.map((def) => def.def);
     const parsedDependencies = dependencies === '' ? [] : dependencies.split(',');
     const options = { dependencies: parsedDependencies };
     const fsh = await runGoFSH(gofshInputStrings, options);
-    props.onGoFSHClick(fsh);
+    props.onGoFSHClick(fsh, false);
   }
 
   return (

--- a/src/tests/components/JSONOutput.test.js
+++ b/src/tests/components/JSONOutput.test.js
@@ -31,7 +31,6 @@ it('Renders with the placeholder text if displaySUSHI is false, isObject is fals
     container
   );
 
-  // Because the editor is in JSON mode, the text is split up differently than the fsh mode
   const placeholderText = getByText('Edit and view FHIR Definitions here!');
 
   expect(placeholderText).toBeInTheDocument();
@@ -39,15 +38,13 @@ it('Renders with the placeholder text if displaySUSHI is false, isObject is fals
 
 it('Renders with the proper text and updates with proper text when not an object', () => {
   const { getByText } = render(
-    <JSONOutput displaySUSHI={true} text={'Loading...'} isObject={false} errorsAndWarnings={[]} isWaiting={true} />,
+    <JSONOutput displaySUSHI={true} text={''} isObject={false} errorsAndWarnings={[]} isWaiting={true} />,
     container
   );
-  const textElement = getByText(
-    (content, element) => element.tagName.toLowerCase() === 'span' && content.startsWith('Loading')
-  );
 
-  expect(textElement).toBeInTheDocument(); // Mimics the 'loading...' case
-  expect(textElement.parentNode.textContent).toEqual('Loading...');
+  const loadingPlaceholderText = getByText('Loading...');
+
+  expect(loadingPlaceholderText).toBeInTheDocument();
 });
 
 // TODO: CodeMirrorComponent doesn't get the package text properly - not sure why
@@ -80,6 +77,7 @@ it.skip('Renders with the first profile when text is an object (SUSHI Package)',
     container
   );
 
+  // Because the editor is in JSON mode, the text is split up differently than the fsh mode
   const resultsElement = getByText(
     (content, element) => element.tagName.toLowerCase() === 'span' && content.startsWith('resourceType')
   );

--- a/src/tests/components/JSONOutput.test.js
+++ b/src/tests/components/JSONOutput.test.js
@@ -184,4 +184,33 @@ describe('file tree display', () => {
     expect(extensionDef.className).toContain('listItemSelected');
     // Can also test that the text in the editor updates when we can access the text correctly
   });
+
+  it('displays Untitled if a definition does not have an id', () => {
+    const profileWithoutId = {
+      profiles: [
+        {
+          resourceType: 'StructureDefinition'
+          // No id field - this is to represent the case when someone removed or never included an id. SUSHI packages should always have ids.
+        }
+      ],
+      extensions: [],
+      instances: [],
+      valueSets: [],
+      codeSystems: []
+    };
+    const { getByText } = render(
+      <JSONOutput
+        displaySUSHI={true}
+        isObject={true}
+        isWaiting={false}
+        setIsOutputObject={() => {}}
+        updateTextValue={() => {}}
+        text={JSON.stringify(profileWithoutId, null, 2)}
+      />,
+      container
+    );
+
+    const untitledDef = getByText('Untitled');
+    expect(untitledDef).toBeInTheDocument();
+  });
 });

--- a/src/tests/components/SUSHIControls.test.js
+++ b/src/tests/components/SUSHIControls.test.js
@@ -53,7 +53,7 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits a bad p
     expect(runSUSHISpy).toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledTimes(2);
     expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false, true);
-    expect(onClick).toHaveBeenCalledWith(true, '', false, false);
+    expect(onClick).toHaveBeenCalledWith(true, [''], false, false);
   });
 });
 
@@ -75,7 +75,7 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits an empt
     expect(runSUSHISpy).toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledTimes(2);
     expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false, true);
-    expect(onClick).toHaveBeenCalledWith(true, '', false, false);
+    expect(onClick).toHaveBeenCalledWith(true, [''], false, false);
   });
 });
 

--- a/src/tests/components/SUSHIControls.test.js
+++ b/src/tests/components/SUSHIControls.test.js
@@ -52,7 +52,7 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits a bad p
     expect(resetLogMessages).toHaveBeenCalledTimes(1);
     expect(runSUSHISpy).toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledTimes(2);
-    expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false, true);
+    expect(onClick).toHaveBeenCalledWith(true, [''], false, true); // Loading
     expect(onClick).toHaveBeenCalledWith(true, [''], false, false);
   });
 });
@@ -74,7 +74,7 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits an empt
     expect(resetLogMessages).toHaveBeenCalledTimes(1);
     expect(runSUSHISpy).toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledTimes(2);
-    expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false, true);
+    expect(onClick).toHaveBeenCalledWith(true, [''], false, true); // Loading
     expect(onClick).toHaveBeenCalledWith(true, [''], false, false);
   });
 });
@@ -96,7 +96,7 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits a good 
     expect(resetLogMessages).toHaveBeenCalledTimes(1);
     expect(runSUSHISpy).toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledTimes(2);
-    expect(onClick).toHaveBeenCalledWith(true, 'Loading...', false, true);
+    expect(onClick).toHaveBeenCalledWith(true, [''], false, true); // Loading
     expect(onClick).toHaveBeenCalledWith(true, JSON.stringify(goodSUSHIPackage, null, 2), true, false);
   });
 });
@@ -117,8 +117,8 @@ it('calls GoFSH function and returns FSH', async () => {
   await wait(() => {
     expect(runGoFSHSpy).toHaveBeenCalled();
     expect(onGoFSHClick).toHaveBeenCalledTimes(2);
-    expect(onGoFSHClick).toHaveBeenCalledWith('Loading...');
-    expect(onGoFSHClick).toHaveBeenCalledWith(simpleFsh);
+    expect(onGoFSHClick).toHaveBeenCalledWith('', true); // Loading
+    expect(onGoFSHClick).toHaveBeenCalledWith(simpleFsh, false);
   });
 });
 


### PR DESCRIPTION
This PR updates the file tree that is rendered on the RHS editor.

A few features of the file tree:
- If the JSON entered for that definition is valid, a check mark is displayed next to its name
- If the JSON is invalid, an X is displayed next to it and the text is colored red and bolded (I don't actually think the bolding is necessary since there is a non-color based visual with the X and I didn't mind it, so I left it for others' opinions)
- Choosing a different definition switches the definition loaded in the editor
- Changing the `id` property in the JSON updates the text in the file tree
- Changing the `resourceType` will re-sort the definition. If it is anything besides "StructureDefinition", "ValueSet", or "CodeSystem", it is sorted under "Instances".

A few implementation/code notes:
- I updated the type of `fhirDefinitions` in the `JSONOutput` component to be a string so that any JSON value is stored, not just valid JSON, letting you keep invalid JSON in one definition while viewing another
- The grey background color of selected definitions doesn't fill the name if the name is long enough to require a horizontal scroll. I couldn't figure out how to do this, so if anyone has any ideas, let me know.
- There isn't a test for typing in invalid JSON and testing that the `listItemError` class is added because I can't figure out how to type directly in the editor within the test. Again, if anyone has any ideas, I'm all for them.
- I did set a `style={{ height: '75vh' }}`, which I think will need to change with the changes to the collapsable console. I'm not sure if now is the right time to rebase the `gofsh` branch (and then this one) to have those changes properly included.