### PR TITLE
Add Definition and Delete Definition buttons

### DIFF
--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -84,7 +84,7 @@ const getIterablePackage = (defsPackage) => {
 export default function JSONOutput(props) {
   const classes = useStyles();
   const [initialText, setInitialText] = useState('');
-  const [fhirDefinitions, setFhirDefinitions] = useState([{}]);
+  const [fhirDefinitions, setFhirDefinitions] = useState([{ resourceType: null, id: 'Untitled', def: null }]);
   const { setIsOutputObject, updateTextValue: propsUpdateText } = props;
   const [currentDef, setCurrentDef] = useState(0);
   const [defsWithErrors, setDefsWithErrors] = useState([]);
@@ -263,9 +263,11 @@ export default function JSONOutput(props) {
           <List component="nav" key={key} className={classes.list}>
             {key}
             {grouped[key]
-              .sort((a, b) =>
-                a.id?.toLowerCase() < b.id?.toLowerCase() ? -1 : a.id?.toLowerCase() > b.id?.toLowerCase() ? 1 : 0
-              ) // Sort ids alphabetically
+              .sort((a, b) => {
+                const aId = a.id ? a.id : 'Untitled'; // Treat missing or blank ids as "Untitled"
+                const bId = b.id ? b.id : 'Untitled';
+                return aId.toLowerCase() < bId.toLowerCase() ? -1 : aId.toLowerCase() > bId.toLowerCase() ? 1 : 0;
+              }) // Sort ids alphabetically
               .map((def, i) => {
                 const currentIndex = fhirDefinitions.indexOf(def);
                 const isError = defsWithErrors.includes(currentIndex);

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -28,7 +28,8 @@ const useStyles = makeStyles((theme) => ({
   },
   button: {
     textTransform: 'none',
-    fontSize: '13px'
+    fontSize: '13px',
+    width: '100%'
   },
   list: {
     padding: '5px',
@@ -57,7 +58,7 @@ const useStyles = makeStyles((theme) => ({
     padding: '3px'
   },
   blankIcon: {
-    width: '19px' // width of icon
+    paddingLeft: '19px' // width of icon
   }
 }));
 

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -172,6 +172,11 @@ export default function JSONOutput(props) {
     updatedDefs.splice(index, 1);
     setFhirDefinitions(updatedDefs);
     setCurrentDef(0);
+    if (defsWithErrors.includes(index)) {
+      const newErrors = [...defsWithErrors];
+      newErrors.splice(defsWithErrors.indexOf(index), 1);
+      setDefsWithErrors(newErrors);
+    }
     const newCurrentDef = updatedDefs.length > 0 ? updatedDefs[0].def : null;
     setInitialText(newCurrentDef);
     setOpenDeleteConfirmation(false);

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -179,11 +179,11 @@ export default function SUSHIControls(props) {
         <Button className={classes.button} onClick={handleRunClick} testid="Button">
           Run SUSHI
         </Button>
+        <Button className={classes.secondaryButton} onClick={handleOpenShare}>
+          Share FSH
+        </Button>
         <Button className={classes.secondaryButton} onClick={handleOpenConfig}>
           Configuration
-        </Button>
-        <Button className={classes.secondaryButton} onClick={handleOpenShare}>
-          Share
         </Button>
         <Button className={classes.button} onClick={handleGoFSHClick} testid="GoFSH-button">
           Run GoFSH
@@ -229,7 +229,7 @@ export default function SUSHIControls(props) {
         <Dialog open={openShare} onClose={handleCloseShare} aria-labelledby="form-dialog-title" maxWidth="sm" fullWidth>
           <DialogTitle id="form-dialog-title">Share</DialogTitle>
           <DialogContent>
-            <DialogContentText>Use this link to share your fsh with others!</DialogContentText>
+            <DialogContentText>Use this link to share your FSH with others!</DialogContentText>
             <TextareaAutosize
               id="link"
               disabled

--- a/src/components/SUSHIControls.js
+++ b/src/components/SUSHIControls.js
@@ -166,7 +166,7 @@ export default function SUSHIControls(props) {
 
   async function handleGoFSHClick() {
     props.onGoFSHClick('', true);
-    const gofshInputStrings = props.gofshText.map((def) => def.def);
+    const gofshInputStrings = props.gofshText.map((def) => def.def).filter((d) => d);
     const parsedDependencies = dependencies === '' ? [] : dependencies.split(',');
     const options = { dependencies: parsedDependencies };
     const fsh = await runGoFSH(gofshInputStrings, options);

--- a/src/tests/components/SUSHIControls.test.js
+++ b/src/tests/components/SUSHIControls.test.js
@@ -237,7 +237,7 @@ it('copies link to clipboard on button click', async () => {
   );
 
   await wait(() => {
-    const shareButton = getByText('Share');
+    const shareButton = getByText('Share FSH');
     fireEvent.click(shareButton);
     expect(generateLinkSpy).toHaveBeenCalled();
   });
@@ -262,7 +262,7 @@ it('generates link when share button is clicked', async () => {
   );
 
   act(() => {
-    const shareButton = getByText('Share');
+    const shareButton = getByText('Share FSH');
     fireEvent.click(shareButton);
   });
   await wait(() => {
@@ -283,7 +283,7 @@ it('shows an error when the FSH file is too long to share', async () => {
     container
   );
   act(() => {
-    const shareButton = getByText('Share');
+    const shareButton = getByText('Share FSH');
     fireEvent.click(shareButton);
   });
   await wait(() => {


### PR DESCRIPTION
This PR adds a "Add definition" button to the file tree on the RHS. This lets you add a blank definition and open a blank editor to type the definition into. As you add text to the definition, the definition should be sorted into the correct category in the file tree and the id should populate.

This also adds a delete button so you can remove a full definition. Deleting the definition will remove it from the file tree and will remove it from the set of definitions that GoFSH is run on if you use the "Run GoFSH" button.