### PR TITLE
Code Fold and Auto Close Bracket plugins

### DIFF
--- a/src/components/CodeMirrorComponent.js
+++ b/src/components/CodeMirrorComponent.js
@@ -10,6 +10,7 @@ import 'codemirror/addon/fold/foldgutter.css';
 require('codemirror/addon/mode/simple');
 require('codemirror/addon/edit/closebrackets');
 require('codemirror/addon/display/placeholder');
+require('codemirror/addon/comment/comment');
 require('codemirror/addon/fold/foldgutter');
 require('codemirror/addon/fold/brace-fold');
 require('codemirror/mode/xml/xml');
@@ -18,6 +19,9 @@ require('codemirror/mode/javascript/javascript');
 // Define FSH syntax highlighting
 // Regular expressions from https://github.com/standardhealth/vscode-language-fsh/blob/master/syntaxes/fsh.tmLanguage.json
 CodeMirror.defineSimpleMode('fsh', {
+  meta: {
+    lineComment: '//'
+  },
   start: [
     // The regex matches the token, the token property contains the type
     {
@@ -91,6 +95,8 @@ export default function CodeMirrorComponent(props) {
           foldGutter: true,
           gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
           extraKeys: {
+            'Ctrl-/': 'toggleComment',
+            'Cmd-/': 'toggleComment',
             'Ctrl-Q': (cm) => {
               cm.foldCode(cm.getCursor());
             }

--- a/src/components/CodeMirrorComponent.js
+++ b/src/components/CodeMirrorComponent.js
@@ -6,9 +6,12 @@ import CodeMirror from 'codemirror';
 import '../style/CodeMirrorComponent.css';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
+import 'codemirror/addon/fold/foldgutter.css';
 require('codemirror/addon/mode/simple');
 require('codemirror/addon/edit/closebrackets');
 require('codemirror/addon/display/placeholder');
+require('codemirror/addon/fold/foldgutter');
+require('codemirror/addon/fold/brace-fold');
 require('codemirror/mode/xml/xml');
 require('codemirror/mode/javascript/javascript');
 
@@ -84,7 +87,14 @@ export default function CodeMirrorComponent(props) {
           theme: 'material',
           placeholder: props.placeholder,
           autoCloseBrackets: true,
-          lineNumbers: true
+          lineNumbers: true,
+          foldGutter: true,
+          gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
+          extraKeys: {
+            'Ctrl-Q': (cm) => {
+              cm.foldCode(cm.getCursor());
+            }
+          }
         }}
         onChange={(editor, data, value) => {
           updateText(value);

--- a/src/components/CodeMirrorComponent.js
+++ b/src/components/CodeMirrorComponent.js
@@ -7,6 +7,7 @@ import '../style/CodeMirrorComponent.css';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
 require('codemirror/addon/mode/simple');
+require('codemirror/addon/edit/closebrackets');
 require('codemirror/addon/display/placeholder');
 require('codemirror/mode/xml/xml');
 require('codemirror/mode/javascript/javascript');
@@ -82,6 +83,7 @@ export default function CodeMirrorComponent(props) {
           mode: props.mode,
           theme: 'material',
           placeholder: props.placeholder,
+          autoCloseBrackets: true,
           lineNumbers: true
         }}
         onChange={(editor, data, value) => {

--- a/src/style/CodeMirrorComponent.css
+++ b/src/style/CodeMirrorComponent.css
@@ -7,3 +7,7 @@
 .react-codemirror2 > .CodeMirror pre.CodeMirror-placeholder {
   color: #546e7a;
 }
+
+.react-codemirror2 > .CodeMirror span.CodeMirror-foldmarker {
+  color: white;
+}


### PR DESCRIPTION
This PR adds two plugins to both editors:
- Auto close brackets will automatically close `()`, `[]`, `{},` `''`, `""`
- Code folding will let you collapse different brackets in the JSON editor. There is an arrow in the gutter that lets you collapse/expand sections similar to VS Code. Also, the example in the documentation also added the collapse/expand to the `Ctrl-Q` keyboard shortcut, so I included that as well. When a section is collapsed, it can also be expanded by clicking the arrow that appears between the collapsed brackets.

Since this just adds existing code mirror plugins, I couldn't think of any tests to add.