### PR TITLE
Canonical and Version configuration updates

### DIFF
--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -175,7 +175,8 @@ export default function FSHControls(props) {
       const igResource = {
         resourceType: 'ImplementationGuide',
         fhirVersion: ['4.0.1'],
-        ...(canonical && { url: canonical }),
+        id: '1',
+        ...(canonical && { url: `${canonical}/ImplementationGuide/1` }),
         ...(version && { version: version })
       };
       gofshInputStrings.push(JSON.stringify(igResource, null, 2));

--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -204,11 +204,9 @@ export default function FSHControls(props) {
           Run GoFSH
         </Button>
         <Dialog open={openConfig} onClose={handleCloseConfig} aria-labelledby="form-dialog-title">
-          <DialogTitle id="form-dialog-title">SUSHI Configuration Settings</DialogTitle>
+          <DialogTitle id="form-dialog-title">Configuration Settings</DialogTitle>
           <DialogContent>
-            <DialogContentText>
-              Change the configuration options to use when running SUSHI on your FSH
-            </DialogContentText>
+            <DialogContentText>Change the configuration options to use when running SUSHI and GoFSH</DialogContentText>
             <TextField
               id="canonical"
               margin="dense"

--- a/src/tests/components/FSHControls.test.js
+++ b/src/tests/components/FSHControls.test.js
@@ -102,13 +102,25 @@ it('calls runSUSHI and changes the doRunSUSHI variable onClick, exhibits a good 
 });
 
 it('calls GoFSH function and returns FSH', async () => {
+  const examplePatient = {
+    resourceType: 'Patient',
+    id: 'MyPatient',
+    gender: 'female'
+  };
   const simpleFsh = ['Instance: MyPatient', 'InstanceOf: Patient', 'Usage: #example', '* gender = #female'].join('\n');
   const onGoFSHClick = jest.fn();
   const resetLogMessages = jest.fn();
-  const runGoFSHSpy = jest.spyOn(fshHelpers, 'runGoFSH').mockReset().mockResolvedValue(simpleFsh);
+  const runGoFSHSpy = jest.spyOn(fshHelpers, 'runGoFSH').mockReset().mockResolvedValue({ fsh: simpleFsh, config: {} });
 
   act(() => {
-    render(<FSHControls onGoFSHClick={onGoFSHClick} gofshText={[]} resetLogMessages={resetLogMessages} />, container);
+    render(
+      <FSHControls
+        onGoFSHClick={onGoFSHClick}
+        gofshText={[{ def: JSON.stringify(examplePatient, null, 2) }]}
+        resetLogMessages={resetLogMessages}
+      />,
+      container
+    );
   });
   const button = document.querySelector('[testid=GoFSH-button]');
   act(() => {
@@ -117,7 +129,59 @@ it('calls GoFSH function and returns FSH', async () => {
 
   await wait(() => {
     expect(resetLogMessages).toHaveBeenCalledTimes(1);
-    expect(runGoFSHSpy).toHaveBeenCalled();
+    expect(runGoFSHSpy).toHaveBeenCalledWith([JSON.stringify(examplePatient, null, 2)], { dependencies: [] }); // No IG resource added because canonical and version set to defaults
+    expect(onGoFSHClick).toHaveBeenCalledTimes(2);
+    expect(onGoFSHClick).toHaveBeenCalledWith('', true); // Loading
+    expect(onGoFSHClick).toHaveBeenCalledWith(simpleFsh, false);
+  });
+});
+
+it('calls GoFSH with user provided canonical and version in mini ImplementationGuide resource if either are set', async () => {
+  const examplePatient = {
+    resourceType: 'Patient',
+    id: 'MyPatient',
+    gender: 'female'
+  };
+  const simpleFsh = ['Instance: MyPatient', 'InstanceOf: Patient', 'Usage: #example', '* gender = #female'].join('\n');
+  const onGoFSHClick = jest.fn();
+  const resetLogMessages = jest.fn();
+  const runGoFSHSpy = jest.spyOn(fshHelpers, 'runGoFSH').mockReset().mockResolvedValue({ fsh: simpleFsh, config: {} });
+  const { getByText, getByLabelText } = render(
+    <FSHControls
+      onGoFSHClick={onGoFSHClick}
+      gofshText={[{ def: JSON.stringify(examplePatient, null, 2) }]}
+      resetLogMessages={resetLogMessages}
+    />,
+    container
+  );
+
+  const configButton = getByText('Configuration');
+  fireEvent.click(configButton);
+  const canonicalInput = getByLabelText('Canonical URL');
+  expect(canonicalInput.value).toEqual(''); // Default
+  fireEvent.change(canonicalInput, { target: { value: 'http://other.org' } });
+  const versionInput = getByLabelText('Version');
+  expect(versionInput.value).toEqual(''); // Default
+  fireEvent.change(versionInput, { target: { value: '2.0.0' } });
+
+  const button = document.querySelector('[testid=GoFSH-button]');
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
+  const expectedIgResource = {
+    resourceType: 'ImplementationGuide',
+    fhirVersion: ['4.0.1'],
+    url: 'http://other.org',
+    version: '2.0.0'
+  };
+
+  await wait(() => {
+    expect(resetLogMessages).toHaveBeenCalledTimes(1);
+    expect(runGoFSHSpy).toHaveBeenCalledWith(
+      [JSON.stringify(examplePatient, null, 2), JSON.stringify(expectedIgResource, null, 2)], // Adds IG resource with canonical and version
+      { dependencies: [] }
+    );
     expect(onGoFSHClick).toHaveBeenCalledTimes(2);
     expect(onGoFSHClick).toHaveBeenCalledWith('', true); // Loading
     expect(onGoFSHClick).toHaveBeenCalledWith(simpleFsh, false);
@@ -137,7 +201,7 @@ it('uses user provided canonical when calling runSUSHI', async () => {
   const configButton = getByText('Configuration');
   fireEvent.click(configButton);
   const canonicalInput = getByLabelText('Canonical URL');
-  expect(canonicalInput.value).toEqual('http://example.org'); // Default
+  expect(canonicalInput.value).toEqual(''); // Default
 
   fireEvent.change(canonicalInput, { target: { value: 'http://other.org' } });
 
@@ -169,10 +233,10 @@ it('uses user provided version when calling runSUSHI', async () => {
 
   const configButton = getByText('Configuration');
   fireEvent.click(configButton);
-  const canonicalInput = getByLabelText('Version');
-  expect(canonicalInput.value).toEqual('1.0.0'); // Default
+  const versionInput = getByLabelText('Version');
+  expect(versionInput.value).toEqual(''); // Default
 
-  fireEvent.change(canonicalInput, { target: { value: '2.0.0' } });
+  fireEvent.change(versionInput, { target: { value: '2.0.0' } });
 
   const button = document.querySelector('[testid=Button]');
   act(() => {

--- a/src/tests/components/FSHControls.test.js
+++ b/src/tests/components/FSHControls.test.js
@@ -172,7 +172,8 @@ it('calls GoFSH with user provided canonical and version in mini ImplementationG
   const expectedIgResource = {
     resourceType: 'ImplementationGuide',
     fhirVersion: ['4.0.1'],
-    url: 'http://other.org',
+    id: '1',
+    url: 'http://other.org/ImplementationGuide/1',
     version: '2.0.0'
   };
 

--- a/src/tests/utils/FSHHelpers.test.js
+++ b/src/tests/utils/FSHHelpers.test.js
@@ -93,9 +93,17 @@ describe('#runGoFSH', () => {
         return Promise.resolve(defs);
       });
     const expectedFSH = ['Instance: MyPatient', 'InstanceOf: Patient', 'Usage: #example'].join('\n');
+    const expectedConfig = {
+      FSHOnly: true,
+      applyExtensionMetadataToRoot: false,
+      canonical: 'http://sample.org',
+      fhirVersion: ['4.0.1'],
+      id: 'sample',
+      name: 'Sample'
+    };
     const outputFSH = await runGoFSH(goFSHDefs, { dependencies });
     expect(loadAndCleanDBSpy).toHaveBeenCalled();
-    expect(outputFSH).toEqual(expectedFSH);
+    expect(outputFSH).toEqual({ fsh: expectedFSH, config: expectedConfig });
   });
 
   it('should return a string of FSH when proper JSON is entered and there are valid FHIRDefinitions', async () => {
@@ -118,10 +126,18 @@ describe('#runGoFSH', () => {
       '* name[0].given[0] = "Jane"',
       '* gender = #female'
     ].join('\n');
+    const expectedConfig = {
+      FSHOnly: true,
+      applyExtensionMetadataToRoot: false,
+      canonical: 'http://sample.org',
+      fhirVersion: ['4.0.1'],
+      id: 'sample',
+      name: 'Sample'
+    };
 
     const outputFSH = await runGoFSH(goFSHDefs, { dependencies });
 
     expect(loadAndCleanDBSpy).toHaveBeenCalled();
-    expect(outputFSH).toEqual(expectedFSH);
+    expect(outputFSH).toEqual({ fsh: expectedFSH, config: expectedConfig });
   });
 });

--- a/src/utils/FSHHelpers.js
+++ b/src/utils/FSHHelpers.js
@@ -54,8 +54,8 @@ export async function runGoFSH(input, options) {
   const configuration = fhirProcessor.processConfig(options.dependencies ?? []);
 
   // Load dependencies, including those inferred from an IG file, and those given as input
-  let dependencies = configuration.config.dependencies
-    ? configuration.config.dependencies.map((dep) => `${dep.packageId}#${dep.version}`)
+  let dependencies = configuration?.config.dependencies
+    ? configuration?.config.dependencies.map((dep) => `${dep.packageId}#${dep.version}`)
     : [];
   dependencies = sliceDependency(dependencies.join(','));
   defs = await loadAndCleanDatabase(defs, dependencies);
@@ -67,7 +67,7 @@ export async function runGoFSH(input, options) {
   const fsh = new gofshExport.FSHExporter(pkg).apiExport('string');
   logger.info('Done converting definitions');
   printGoFSHresults(pkg);
-  return fsh;
+  return { fsh, config: configuration?.config ?? {} };
 }
 
 /**


### PR DESCRIPTION
This PR updates how the Configuration modals works with GoFSH and SUSHI so that we can successfully "round trip" within FSH Online.

When no values are set, we leave the fields blank and indicate the default values that SUSHI will use. If there are no values set when SUSHI runs, it will use the default `example.org` and `1.0.0` values. If there are no values when GoFSH is run, GoFSH will infer the values from the definitions, and then set the canonical and version value in modal, which will be used by SUSHI the next time SUSHI is run, completing the round trip.

If there are values set in modal when running SUSHI, SUSHI will use those. If there are values set in the modal when running GoFSH, GoFSH will use those as the configuration and set caret value rules for the actual canonical and version values in the definitions. It will not update the modal with the configuration it determines from that set of definitions, since the modal already has values and will not be overwritten.