### PR TITLE
Update JSON file list to organize by FSH entity

### DIFF
--- a/src/utils/FSHHelpers.js
+++ b/src/utils/FSHHelpers.js
@@ -128,32 +128,37 @@ function printSUSHIResults(pkg) {
   const numError = stats.numError;
   const numWarn = stats.numWarn;
   // NOTE: These variables are creatively names to align well in the strings below while keeping prettier happy
-  const prNum = pad(pkg.profiles.length.toString(), 8);
-  const extnNum = pad(pkg.extensions.length.toString(), 10);
-  const lgNum = pad(pkg.logicals.length.toString(), 8);
-  const resNum = pad(pkg.resources.length.toString(), 9);
-  const vstNum = pad(pkg.valueSets.length.toString(), 9);
-  const cdsysNum = pad(pkg.codeSystems.length.toString(), 11);
-  const insNum = pad(pkg.instances.length.toString(), 9);
+  const profileNum = pad(pkg.profiles.length.toString(), 13);
+  const extentNum = pad(pkg.extensions.length.toString(), 12);
+  const logiclNum = pad(pkg.logicals.length.toString(), 12);
+  const resourcNum = pad(pkg.resources.length.toString(), 13);
+  const valueSetsNumber = pad(pkg.valueSets.length.toString(), 18);
+  const codeSystemsNum = pad(pkg.codeSystems.length.toString(), 17);
+  const instancesNumber = pad(pkg.instances.length.toString(), 18);
   const errorNumMsg = pad(`${numError} Error${numError !== 1 ? 's' : ''}`, 13);
   const wrNumMsg = padStart(`${numWarn} Warning${numWarn !== 1 ? 's' : ''}`, 12);
 
-  const aWittyMessageInvolvingABadFishPun = padEnd(getRandomPun(numError, numWarn), 59);
+  const aWittyMessageInvolvingABadFishPun = padEnd(getRandomPun(numError, numWarn), 36);
   const color = numError > 0 ? 'red' : numWarn > 0 ? '#b36200' : 'green'; // eslint-disable-line no-unused-vars
 
   /* eslint-disable no-useless-concat */
   // NOTE: Doing some funky things w/ strings on some lines to keep overall alignment in the code
   const results = [
-    '╔' + '═══════════════════════════════════ SUSHI RESULTS ══════════════════════════════════════' + '╗',
-    '║' + ' ╭──────────┬────────────┬──────────┬───────────┬───────────┬─────────────┬───────────╮ ' + '║',
-    '║' + ' │ Profiles │ Extensions │ Logicals │ Resources │ ValueSets │ CodeSystems │ Instances │ ' + '║',
-    '║' + ' ├──────────┼────────────┼──────────┼───────────┼───────────┼─────────────┼───────────┤ ' + '║',
-    '║' + ` │ ${prNum} │ ${extnNum} │ ${lgNum} │ ${resNum} │ ${vstNum} │ ${cdsysNum} │ ${insNum} │ ` + '║',
-    '║' + ' ╰──────────┴────────────┴──────────┴───────────┴───────────┴─────────────┴───────────╯ ' + '║',
-    '║' + '                                                                                        ' + '║',
-    '╠' + '════════════════════════════════════════════════════════════════════════════════════════' + '╣',
+    '╔' + '════════════════════════ SUSHI RESULTS ══════════════════════════' + '╗',
+    '║' + ' ╭───────────────┬──────────────┬──────────────┬───────────────╮ ' + '║',
+    '║' + ' │    Profiles   │  Extensions  │   Logicals   │   Resources   │ ' + '║',
+    '║' + ' ├───────────────┼──────────────┼──────────────┼───────────────┤ ' + '║',
+    '║' + ` │ ${profileNum} │ ${extentNum} │ ${logiclNum} │ ${resourcNum} │ ` + '║',
+    '║' + ' ╰───────────────┴──────────────┴──────────────┴───────────────╯ ' + '║',
+    '║' + ' ╭────────────────────┬───────────────────┬────────────────────╮ ' + '║',
+    '║' + ' │      ValueSets     │    CodeSystems    │     Instances      │ ' + '║',
+    '║' + ' ├────────────────────┼───────────────────┼────────────────────┤ ' + '║',
+    '║' + ` │ ${valueSetsNumber} │ ${codeSystemsNum} │ ${instancesNumber} │ ` + '║',
+    '║' + ' ╰────────────────────┴───────────────────┴────────────────────╯ ' + '║',
+    '║' + '                                                                 ' + '║',
+    '╠' + '═════════════════════════════════════════════════════════════════' + '╣',
     '║' + ` ${aWittyMessageInvolvingABadFishPun} ${errorNumMsg} ${wrNumMsg} ` + '║',
-    '╚' + '════════════════════════════════════════════════════════════════════════════════════════' + '╝'
+    '╚' + '═════════════════════════════════════════════════════════════════' + '╝'
   ];
   results.forEach((r) => console.log(r));
   // results.forEach((r) => console.log(`%c${r}`, `color:${clr}`)); // Color formatting for browser console


### PR DESCRIPTION
This PR updates the organization of the JSON files we display on the far right side of the page. Instead of grouping definitions by the FHIR `resourceType`, they are now grouped by the FSH entity type that they came from or will become when running GoFSH. This reflects the default output style of GoFSH once we release a new version. I don't think that the GoFSH release should hold up the merge of this PR since it is still a valid way to organize the files.

The one area I'd definitely like feedback on is if the criteria I'm using for differentiating between Profiles, Extensions, Logical Models, and Resources is sufficient. I used the criteria from GoFSH [here](https://github.com/FHIR/GoFSH/blob/master/src/processor/LakeOfFHIR.ts#L92-L112) (which I believe @mint-thompson added recently). It seems to be working as expected, but I could be missing something.

I also updated the size of the box that SUSHI outputs to match the narrower box in SUSHI.