### PR TITLE
Support sharing configuration in links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -196,10 +196,16 @@ export default function App(props) {
   const [exampleFilePaths, setExampleFilePaths] = useState({});
   const [leftWidth, setLeftWidth] = useState(41.666667); // Initial width based off grid item xs={5} size to align with FSHControls
   const [isDragging, setIsDragging] = useState(false);
+  const [config, setConfig] = useState();
 
   useEffect(() => {
     async function waitForFSH() {
-      setInitialText(await decodeFSH(urlParam.params));
+      const text = await decodeFSH(urlParam.params);
+      const splitIndex = text.indexOf('\n');
+      const config = text.slice(0, splitIndex);
+      const fshContent = text.slice(splitIndex + 1);
+      setConfig(JSON.parse(config));
+      setInitialText(fshContent);
     }
     async function fetchExamples() {
       setExampleConfig(await getManifestFromGit());
@@ -238,6 +244,10 @@ export default function App(props) {
 
   function updateInputFHIRTextValue(text) {
     setInputFHIRText(text);
+  }
+
+  function handleConfigChange(config) {
+    setConfig(config);
   }
 
   function handleResetWidth() {
@@ -293,6 +303,8 @@ export default function App(props) {
           <FSHControls
             onSUSHIClick={handleSUSHIControls}
             onGoFSHClick={handleGoFSHControls}
+            onConfigChange={handleConfigChange}
+            config={config}
             fshText={inputFSHText}
             gofshText={inputFHIRText}
             resetLogMessages={resetLogMessages}
@@ -322,6 +334,7 @@ export default function App(props) {
                   updateTextValue={updateInputFSHTextValue}
                   isWaiting={isWaitingForFSHOutput}
                   setInitialText={setInitialText}
+                  config={config}
                 />
               </Grid>
               <Grid

--- a/src/App.js
+++ b/src/App.js
@@ -196,7 +196,8 @@ export default function App(props) {
   const [exampleFilePaths, setExampleFilePaths] = useState({});
   const [leftWidth, setLeftWidth] = useState(41.666667); // Initial width based off grid item xs={5} size to align with FSHControls
   const [isDragging, setIsDragging] = useState(false);
-  const [config, setConfig] = useState();
+  const [configToShare, setConfigToShare] = useState({});
+  const [sharedConfig, setSharedConfig] = useState({});
 
   useEffect(() => {
     async function waitForFSH() {
@@ -204,7 +205,7 @@ export default function App(props) {
       const splitIndex = text.indexOf('\n');
       const config = text.slice(0, splitIndex);
       const fshContent = text.slice(splitIndex + 1);
-      setConfig(JSON.parse(config));
+      setSharedConfig(config ? JSON.parse(config) : {});
       setInitialText(fshContent);
     }
     async function fetchExamples() {
@@ -247,7 +248,7 @@ export default function App(props) {
   }
 
   function handleConfigChange(config) {
-    setConfig(config);
+    setConfigToShare(config);
   }
 
   function handleResetWidth() {
@@ -304,7 +305,7 @@ export default function App(props) {
             onSUSHIClick={handleSUSHIControls}
             onGoFSHClick={handleGoFSHControls}
             onConfigChange={handleConfigChange}
-            config={config}
+            config={sharedConfig}
             fshText={inputFSHText}
             gofshText={inputFHIRText}
             resetLogMessages={resetLogMessages}
@@ -334,7 +335,7 @@ export default function App(props) {
                   updateTextValue={updateInputFSHTextValue}
                   isWaiting={isWaitingForFSHOutput}
                   setInitialText={setInitialText}
-                  config={config}
+                  config={configToShare}
                 />
               </Grid>
               <Grid

--- a/src/App.js
+++ b/src/App.js
@@ -196,7 +196,7 @@ export default function App(props) {
   const [exampleFilePaths, setExampleFilePaths] = useState({});
   const [leftWidth, setLeftWidth] = useState(41.666667); // Initial width based off grid item xs={5} size to align with FSHControls
   const [isDragging, setIsDragging] = useState(false);
-  const [configToShare, setConfigToShare] = useState({});
+  const [configToShare, setConfigToShare] = useState({ canonical: '', version: '', dependencies: '' });
   const [sharedConfig, setSharedConfig] = useState({});
 
   useEffect(() => {
@@ -204,8 +204,17 @@ export default function App(props) {
       const text = await decodeFSH(urlParam.params);
       const splitIndex = text.indexOf('\n');
       const config = text.slice(0, splitIndex);
-      const fshContent = text.slice(splitIndex + 1);
-      setSharedConfig(config ? JSON.parse(config) : {});
+      let parsedConfig;
+      let fshContent = text;
+      try {
+        parsedConfig = JSON.parse(config);
+        if (parsedConfig.canonical != null && parsedConfig.version != null && parsedConfig.dependencies != null) {
+          // If the config is successfully parsed and has the expected properties,
+          // we can assume the true FSH content begins on the next line
+          fshContent = text.slice(splitIndex + 1);
+        }
+      } catch (e) {}
+      setSharedConfig(parsedConfig || {});
       setInitialText(fshContent);
     }
     async function fetchExamples() {

--- a/src/App.js
+++ b/src/App.js
@@ -207,8 +207,9 @@ export default function App(props) {
       let parsedConfig;
       let fshContent = text;
       try {
-        parsedConfig = JSON.parse(config);
-        if (parsedConfig.canonical != null && parsedConfig.version != null && parsedConfig.dependencies != null) {
+        const rawConfig = JSON.parse(config);
+        if (rawConfig.c != null && rawConfig.v != null && rawConfig.d != null) {
+          parsedConfig = { canonical: rawConfig.c, version: rawConfig.v, dependencies: rawConfig.d };
           // If the config is successfully parsed and has the expected properties,
           // we can assume the true FSH content begins on the next line
           fshContent = text.slice(splitIndex + 1);

--- a/src/App.js
+++ b/src/App.js
@@ -213,7 +213,10 @@ export default function App(props) {
           // we can assume the true FSH content begins on the next line
           fshContent = text.slice(splitIndex + 1);
         }
-      } catch (e) {}
+      } catch (e) {
+        // If parse fails, it is likely decoding a legacy link in which all content is FSH, so just don't
+        // set the parsedConfig, and set fshContent to all of the text
+      }
       setSharedConfig(parsedConfig || {});
       setInitialText(fshContent);
     }

--- a/src/components/CodeMirrorComponent.js
+++ b/src/components/CodeMirrorComponent.js
@@ -228,7 +228,7 @@ export default function CodeMirrorComponent(props) {
     return (
       <div className={classes.headerActions}>
         <div className={classes.headerActionGroup}>
-          {props.mode === 'fsh' && !props.isExamples && <ShareLink shareText={props.value} />}
+          {props.mode === 'fsh' && !props.isExamples && <ShareLink shareText={props.value} config={props.config} />}
           {props.copy && renderActionIcon(FileCopy, 'copy', () => {})}
           {props.save && renderActionIcon(SaveAlt, 'save', () => {})}
           {props.delete && renderActionIcon(Delete, 'delete', props.delete)}

--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -99,13 +99,13 @@ export default function FSHControls(props) {
   const [currentExampleName, setCurrentExampleName] = useState('');
 
   if (!canonical && props.config?.canonical) {
-    setCanonical(props.config?.canonical);
+    setCanonical(props.config.canonical);
   }
   if (!version && props.config?.version) {
-    setVersion(props.config?.version);
+    setVersion(props.config.version);
   }
   if (!dependencies && props.config?.dependencies) {
-    setDependencies(props.config?.dependencies);
+    setDependencies(props.config.dependencies);
   }
 
   const handleOpenExamples = () => {

--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import clsx from 'clsx';
 import { makeStyles } from '@material-ui/core/styles';
 import { PlayArrow, Settings } from '@material-ui/icons';
@@ -98,15 +98,11 @@ export default function FSHControls(props) {
   const [currentExample, setCurrentExample] = useState('');
   const [currentExampleName, setCurrentExampleName] = useState('');
 
-  if (!canonical && props.config?.canonical) {
-    setCanonical(props.config.canonical);
-  }
-  if (!version && props.config?.version) {
-    setVersion(props.config.version);
-  }
-  if (!dependencies && props.config?.dependencies) {
-    setDependencies(props.config.dependencies);
-  }
+  useEffect(() => {
+    setCanonical(props.config?.canonical || '');
+    setVersion(props.config?.version || '');
+    setDependencies(props.config?.dependencies || '');
+  }, [props.config]);
 
   const handleOpenExamples = () => {
     setOpenExamples(true);

--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -98,6 +98,16 @@ export default function FSHControls(props) {
   const [currentExample, setCurrentExample] = useState('');
   const [currentExampleName, setCurrentExampleName] = useState('');
 
+  if (!canonical && props.config?.canonical) {
+    setCanonical(props.config?.canonical);
+  }
+  if (!version && props.config?.version) {
+    setVersion(props.config?.version);
+  }
+  if (!dependencies && props.config?.dependencies) {
+    setDependencies(props.config?.dependencies);
+  }
+
   const handleOpenExamples = () => {
     setOpenExamples(true);
   };
@@ -113,6 +123,7 @@ export default function FSHControls(props) {
 
   const handleCloseConfig = () => {
     setOpenConfig(false);
+    props.onConfigChange({ canonical, version, dependencies });
   };
 
   const updateCanonical = (event) => {

--- a/src/components/FSHOutput.js
+++ b/src/components/FSHOutput.js
@@ -25,6 +25,7 @@ export default function FSHOutput(props) {
         mode={'fsh'}
         placeholder={props.isWaiting ? 'Loading...' : 'Paste or edit FSH here...'}
         delete={handleOpenDeleteModal}
+        config={props.config}
       />
       {openDeleteModal && (
         <DeleteConfirmationModal

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -41,8 +41,16 @@ export default function ShareLink(props) {
   };
 
   const handleOpenShare = async () => {
-    const itsyBitsyConfig = { c: props.config?.canonical, v: props.config?.version, d: props.config?.dependencies };
-    const encoded = deflateSync(JSON.stringify(itsyBitsyConfig) + '\n' + props.shareText).toString('base64');
+    let encoded;
+    if (props.config?.canonical || props.config?.version || props.config?.dependencies) {
+      encoded = deflateSync(
+        JSON.stringify({ c: props.config?.canonical, v: props.config?.version, d: props.config?.dependencies }) +
+          '\n' +
+          props.shareText
+      ).toString('base64');
+    } else {
+      encoded = deflateSync(props.shareText).toString('base64');
+    }
     const longLink = `https://fshschool.org/FSHOnline/#/share/${encoded}`;
     const bitlyLink = await generateLink(longLink);
     if (bitlyLink.errorNeeded === true) {

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -41,7 +41,7 @@ export default function ShareLink(props) {
   };
 
   const handleOpenShare = async () => {
-    const encoded = deflateSync(JSON.stringify(props.config || {}) + '\n' + props.shareText).toString('base64');
+    const encoded = deflateSync(JSON.stringify(props.config) + '\n' + props.shareText).toString('base64');
     const longLink = `https://fshschool.org/FSHOnline/#/share/${encoded}`;
     const bitlyLink = await generateLink(longLink);
     if (bitlyLink.errorNeeded === true) {

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -41,7 +41,8 @@ export default function ShareLink(props) {
   };
 
   const handleOpenShare = async () => {
-    const encoded = deflateSync(JSON.stringify(props.config) + '\n' + props.shareText).toString('base64');
+    const itsyBitsyConfig = { c: props.config?.canonical, v: props.config?.version, d: props.config?.dependencies };
+    const encoded = deflateSync(JSON.stringify(itsyBitsyConfig) + '\n' + props.shareText).toString('base64');
     const longLink = `https://fshschool.org/FSHOnline/#/share/${encoded}`;
     const bitlyLink = await generateLink(longLink);
     if (bitlyLink.errorNeeded === true) {

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -41,7 +41,7 @@ export default function ShareLink(props) {
   };
 
   const handleOpenShare = async () => {
-    const encoded = deflateSync(props.shareText).toString('base64');
+    const encoded = deflateSync(JSON.stringify(props.config || {}) + '\n' + props.shareText).toString('base64');
     const longLink = `https://fshschool.org/FSHOnline/#/share/${encoded}`;
     const bitlyLink = await generateLink(longLink);
     if (bitlyLink.errorNeeded === true) {

--- a/src/tests/components/ShareLink.test.js
+++ b/src/tests/components/ShareLink.test.js
@@ -78,7 +78,7 @@ it('generates link with configuration when share button is clicked', async () =>
     fireEvent.click(shareButton);
   });
   await wait(() => {
-    expect(deflateSpy).toHaveBeenCalledWith('{"canonical":"http://example.org"}\nProfile: A');
+    expect(deflateSpy).toHaveBeenCalledWith('{"c":"http://example.org"}\nProfile: A');
     expect(generateLinkSpy).toHaveBeenCalledWith('https://fshschool.org/FSHOnline/#/share/foo');
   });
 });


### PR DESCRIPTION
This addresses [CIMPL-711](https://standardhealthrecord.atlassian.net/browse/CIMPL-711) by adding support for sharing configuration information when sharing links. If there is information entered into the config modal, and you share a set of FSH, when you visit the generated link, the configuration information should be prepopulated with what was there when you generated the link.