### PR TITLE
Don't add resources without an id or resourceType

### DIFF
--- a/src/utils/Load.js
+++ b/src/utils/Load.js
@@ -57,7 +57,9 @@ export function loadDependenciesInStorage(database, resources, dependency, id) {
     };
     const objectStore = transaction.objectStore(`${dependency}${id}`, { keyPath: ['id', 'resourceType'] });
     resources.forEach((res) => {
-      objectStore.put(res);
+      if (res.id != null && res.resourceType != null) {
+        objectStore.put(res);
+      }
     });
   });
 }

--- a/src/utils/Load.js
+++ b/src/utils/Load.js
@@ -57,7 +57,7 @@ export function loadDependenciesInStorage(database, resources, dependency, id) {
     };
     const objectStore = transaction.objectStore(`${dependency}${id}`, { keyPath: ['id', 'resourceType'] });
     resources.forEach((res) => {
-      if (res.id != null && res.resourceType != null) {
+      if (res.id && res.resourceType) {
         objectStore.put(res);
       }
     });


### PR DESCRIPTION
This fixes the bug found [here](https://github.com/FSHSchool/FSHOnline/pull/65#issuecomment-889976876).

When using hl7.fhir.us.core#4.0.0 as a dependency, there is a bundle that does not have an id. This causes FSH Online to crash because we use both `id` and `resourceType` to create a keypath to the resource in indexedDB.

@ngfreiter helped me accomplish this great solution.