### PR TITLE
Update to SUSHI 2.0.0 (stable)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6742,15 +6742,15 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "2.0.0-beta.1-fshonline-hotfix",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-2.0.0-beta.1-fshonline-hotfix.tgz",
-      "integrity": "sha512-h8B396MTZeFHCTyOz7dYa/cd9gzE1hTlLJ81jVNRiqwHIiMsZuAgyO5w24hUUaQ4yvEgF5IvyypIy8zjKEStvg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-2.0.0.tgz",
+      "integrity": "sha512-ONpWk2GEKTf0TpzSDvvSXtMed1D/47yDY2B42YsXNqvbg7mtmeYwjD8TSPLxsh13OXf0iKA9DccESyYsUZC38A==",
       "requires": {
         "antlr4": "~4.8.0",
         "axios": "^0.21.1",
         "chalk": "^3.0.0",
         "commander": "^4.1.1",
-        "fhir": "^4.8.2",
+        "fhir": "^4.9.0",
         "fs-extra": "^8.1.0",
         "html-minifier": "^4.0.0",
         "ini": "^1.3.8",
@@ -9606,9 +9606,9 @@
           "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
         },
         "fhir": {
-          "version": "4.8.2",
-          "resolved": "https://registry.npmjs.org/fhir/-/fhir-4.8.2.tgz",
-          "integrity": "sha512-4F29bMxILAxrFaSYMsmCaJ8NcUYfzqMhzCnYJCSYVWctNbf5I7KSXhRBsCkrHUoz7rcFMfuL4gSAziF1Qcz2hQ==",
+          "version": "4.9.0",
+          "resolved": "https://registry.npmjs.org/fhir/-/fhir-4.9.0.tgz",
+          "integrity": "sha512-x+4LzzcNURfgzTbhDdaLxYNj8L84akM+jVvpuEQNxXggchqH5cPCC1cEWl2PUfJTT/tN8WkhM1tY2xOQI/t/rA==",
           "requires": {
             "lodash": "^4.17.19",
             "path": "^0.12.7",
@@ -9622,7 +9622,7 @@
               "bundled": true
             },
             "lodash": {
-              "version": "4.17.19",
+              "version": "4.17.21",
               "bundled": true
             },
             "path": {
@@ -13498,9 +13498,9 @@
           }
         },
         "trim-newlines": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-          "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA=="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+          "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
         },
         "triple-beam": {
           "version": "1.3.0",
@@ -13916,9 +13916,9 @@
           }
         },
         "ws": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-          "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g=="
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.2.tgz",
+          "integrity": "sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ=="
         },
         "xml-name-validator": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bitly": "^7.1.2",
     "browserify-zlib": "^0.2.0",
     "codemirror": "^5.54.0",
-    "fsh-sushi": "^2.0.0-beta.1-fshonline-hotfix",
+    "fsh-sushi": "^2.0.0",
     "gofsh": "^1.2.0",
     "lodash": "^4.17.19",
     "null-loader": "^4.0.0",

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -59,7 +59,7 @@ export default function TopBar() {
                   FSH ONLINE
                 </Typography>
                 <Typography order={2} className={classes.versionText}>
-                  Powered by SUSHI v2.0.0-beta.1 and GoFSH v1.2.0
+                  Powered by SUSHI v2.0.0 and GoFSH v1.2.0
                 </Typography>
               </StylesProvider>
             </Box>


### PR DESCRIPTION
Upgrades the FSHOnline's fsh-sushi dependency to version 2.0.0.