### PR TITLE
Update to use GoFSH 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2701,9 +2701,9 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
+      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
     },
     "async-each": {
       "version": "1.0.3",
@@ -3714,9 +3714,9 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4897,12 +4897,12 @@
       "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew=="
     },
     "diff2html": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-3.4.5.tgz",
-      "integrity": "sha512-EvLFeEq4ZAG3URzajoNr2T1C2oQSRYpG+wlPj6d7xKua1+GY6XjZglTobERZUkMm4LyETTmzqHf19kpQljAcgA==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-3.4.9.tgz",
+      "integrity": "sha512-33x45h6Xgfasjt49e0ldfLnUdCjLjHIdablpAlrKnQyyG1RA7w+4cbp9+bUfNLxfFj584BookXqh5KJEt4+MLA==",
       "requires": {
         "diff": "5.0.0",
-        "highlight.js": "10.7.2",
+        "highlight.js": "11.1.0",
         "hogan.js": "3.0.2"
       }
     },
@@ -6262,9 +6262,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
+      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -6288,9 +6288,9 @@
       "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
     "fhir": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/fhir/-/fhir-4.8.2.tgz",
-      "integrity": "sha512-4F29bMxILAxrFaSYMsmCaJ8NcUYfzqMhzCnYJCSYVWctNbf5I7KSXhRBsCkrHUoz7rcFMfuL4gSAziF1Qcz2hQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fhir/-/fhir-4.9.0.tgz",
+      "integrity": "sha512-x+4LzzcNURfgzTbhDdaLxYNj8L84akM+jVvpuEQNxXggchqH5cPCC1cEWl2PUfJTT/tN8WkhM1tY2xOQI/t/rA==",
       "requires": {
         "lodash": "^4.17.19",
         "path": "^0.12.7",
@@ -6304,7 +6304,7 @@
           "bundled": true
         },
         "lodash": {
-          "version": "4.17.19",
+          "version": "4.17.21",
           "bundled": true
         },
         "path": {
@@ -14136,20 +14136,20 @@
       }
     },
     "gofsh": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gofsh/-/gofsh-1.2.0.tgz",
-      "integrity": "sha512-lKnbjbRsWIBXLSwV1kyuo7uuvBkL9eNztkWNaSjGAdpmlUHqpnsEDnMfOmSqMWH8PkbS+hG3O0+8lJ/DhrGzzQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gofsh/-/gofsh-1.3.0.tgz",
+      "integrity": "sha512-P5dacFs36ocKhzz30SoVM7+qQWMuc1ESejfWZ7IQaYtFcQQIt+iyef2qTsd93RVyXGCs+IUxTF7sbvgIAguyXw==",
       "requires": {
         "chalk": "^4.1.0",
         "commander": "^6.0.0",
         "diff": "^5.0.0",
         "diff2html": "^3.1.18",
-        "fhir": "^4.8.2",
+        "fhir": "^4.8.3",
         "flat": "^5.0.2",
         "fs-extra": "^9.0.1",
-        "fsh-sushi": "^2.0.0-beta.1",
-        "ini": "^1.3.5",
-        "lodash": "^4.17.19",
+        "fsh-sushi": "^2.0.0",
+        "ini": "^1.3.8",
+        "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
         "semver": "^7.3.2",
         "temp": "^0.9.1",
@@ -14184,6 +14184,11 @@
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lru-cache": {
           "version": "6.0.0",
@@ -14350,9 +14355,9 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
     "highlight.js": {
-      "version": "10.7.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
-      "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.1.0.tgz",
+      "integrity": "sha512-X9VVhYKHQPPuwffO8jk4bP/FVj+ibNCy3HxZZNDXFtJrq4O5FdcdCDRIkDis5MiMnjh7UwEdHgRZJcHFYdzDdA==",
       "optional": true
     },
     "history": {
@@ -15084,9 +15089,9 @@
       "integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg=="
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-string": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "browserify-zlib": "^0.2.0",
     "codemirror": "^5.54.0",
     "fsh-sushi": "^2.0.0",
-    "gofsh": "^1.2.0",
+    "gofsh": "^1.3.0",
     "lodash": "^4.17.19",
     "null-loader": "^4.0.0",
     "react": "^16.13.1",

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -97,7 +97,7 @@ const checkFshType = (def) => {
     } else if (def.derivation === 'constraint') {
       if (def.kind === 'complex-type' && def.type === 'Extension') {
         return 'Extension';
-      } else if (['resource', 'complex-type', 'primitive-type'].includes(def.kind)) {
+      } else if (['resource', 'complex-type', 'primitive-type', 'logical'].includes(def.kind)) {
         return 'Profile';
       }
     }

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -59,7 +59,7 @@ export default function TopBar() {
                   FSH ONLINE
                 </Typography>
                 <Typography order={2} className={classes.versionText}>
-                  Powered by SUSHI v2.0.0 and GoFSH v1.2.0
+                  Powered by SUSHI v2.0.0 and GoFSH v1.3.0
                 </Typography>
               </StylesProvider>
             </Box>

--- a/src/utils/FSHHelpers.js
+++ b/src/utils/FSHHelpers.js
@@ -12,7 +12,6 @@ const stats = utils.stats;
 const getRandomPun = utils.getRandomPun;
 const Type = utils.Type;
 const FHIRDefinitions = fhirdefs.FHIRDefinitions;
-const { getRandomSeaCreatures, getRandomSeaCreaturesStat } = gofshUtils;
 
 /**
  * Run GoFSH
@@ -40,7 +39,7 @@ export async function runGoFSH(input, options) {
       return;
     }
     if (gofshUtils.isProcessableContent(resource, location)) {
-      docs.push(new processor.WildFHIR(resource, location));
+      docs.push(new processor.WildFHIR({ content: resource }, location));
     }
   });
 
@@ -165,36 +164,41 @@ function printSUSHIResults(pkg) {
 }
 
 function printGoFSHresults(pkg) {
-  const proNum = pad(pkg.profiles.length.toString(), 12);
-  const extNum = pad(pkg.extensions.length.toString(), 13);
-  const vsNum = pad(pkg.valueSets.length.toString(), 12);
-  const csNum = pad(pkg.codeSystems.length.toString(), 13);
-  const instNum = pad(pkg.instances.length.toString(), 12);
-  const invNum = pad(pkg.invariants.length.toString(), 13);
-  const mapNum = pad(pkg.mappings.length.toString(), 12);
+  const proNum = pad(pkg.profiles.length.toString(), 18);
+  const extNum = pad(pkg.extensions.length.toString(), 17);
+  const logNum = pad(pkg.logicals.length.toString(), 18);
+  const resNum = pad(pkg.resources.length.toString(), 18);
+  const vsNum = pad(pkg.valueSets.length.toString(), 17);
+  const csNum = pad(pkg.codeSystems.length.toString(), 18);
+  const instNum = pad(pkg.instances.length.toString(), 18);
+  const invNum = pad(pkg.invariants.length.toString(), 17);
+  const mapNum = pad(pkg.mappings.length.toString(), 18);
   const errNumMsg = pad(`${stats.numError} Error${stats.numError !== 1 ? 's' : ''}`, 12);
   const wrnNumMsg = padStart(`${stats.numWarn} Warning${stats.numWarn !== 1 ? 's' : ''}`, 12);
-  const creatures = pad(getRandomSeaCreatures(), 13);
-  const creatrStat = pad(getRandomSeaCreaturesStat(stats.numError, stats.numWarn), 13);
   const aWittyMessageInvolvingABadFishPun = padEnd(getRandomPun(stats.numError, stats.numWarn), 37);
 
   // prettier-ignore
   const results = [
-    '╔'  + '═════════════════════════ GoFSH RESULTS ═════════════════════════' +'╗',
-    '║' + ' ╭──────────────┬───────────────┬──────────────┬───────────────╮ ' + '║',
-    '║' + ' │   Profiles   │  Extensions   │  ValueSets   │  CodeSystems  │ ' + '║',
-    '║' + ' ├──────────────┼───────────────┼──────────────┼───────────────┤ ' + '║',
-    '║' + ` │ ${ proNum  } │ ${  extNum  } │ ${  vsNum  } │ ${  csNum   } │ ` + '║',
-    '║' + ' ╰──────────────┴───────────────┴──────────────┴───────────────╯ ' + '║',
-    '║' + ' ╭──────────────┬───────────────┬──────────────┬───────────────╮ ' + '║',
-    '║' + ` │  Instances   │  Invariants   │   Mappings   │ ${creatures } │ ` + '║',
-    '║' + ' ├──────────────┼───────────────┼──────────────┼───────────────┤ ' + '║',
-    '║' + ` │ ${ instNum } │ ${  invNum  } │ ${ mapNum  } │ ${creatrStat} │ ` + '║',
-    '║' + ' ╰──────────────┴───────────────┴──────────────┴───────────────╯ ' + '║',
+    '╔' + '═════════════════════════ GoFSH RESULTS ═════════════════════════' + '╗',
+    '║' + ' ╭────────────────────┬───────────────────┬────────────────────╮ ' + '║',
+    '║' + ' │      Profiles      │    Extensions     │      Logicals      │ ' + '║',
+    '║' + ' ├────────────────────┼───────────────────┼────────────────────┤ ' + '║',
+    '║' + ` │ ${    proNum     } │ ${    extNum    } │ ${    logNum     } │ ` + '║',
+    '║' + ' ╰────────────────────┴───────────────────┴────────────────────╯ ' + '║',
+    '║' + ' ╭────────────────────┬───────────────────┬────────────────────╮ ' + '║',
+    '║' + ' │     Resources      │     ValueSets     │     CodeSystems    │ ' + '║',
+    '║' + ' ├────────────────────┼───────────────────┼────────────────────┤ ' + '║',
+    '║' + ` │ ${    resNum     } │ ${    vsNum     } │ ${     csNum     } │ ` + '║',
+    '║' + ' ╰────────────────────┴───────────────────┴────────────────────╯ ' + '║',
+    '║' + ' ╭────────────────────┬───────────────────┬────────────────────╮ ' + '║',
+    '║' + ' │     Instances      │    Invariants     │      Mappings      │ ' + '║',
+    '║' + ' ├────────────────────┼───────────────────┼────────────────────┤ ' + '║',
+    '║' + ` │ ${    instNum    } │ ${    invNum    } │ ${    mapNum     } │ ` + '║',
+    '║' + ' ╰────────────────────┴───────────────────┴────────────────────╯ ' + '║',
     '║' + '                                                                 ' + '║',
-    '╠'  + '═════════════════════════════════════════════════════════════════' +'╣',
+    '╠' + '═════════════════════════════════════════════════════════════════' + '╣',
     '║' + ` ${aWittyMessageInvolvingABadFishPun } ${errNumMsg} ${wrnNumMsg} ` + '║',
-    '╚'  + '═════════════════════════════════════════════════════════════════' +'╝'
+    '╚' + '═════════════════════════════════════════════════════════════════' + '╝'
   ];
 
   console.log(' ');


### PR DESCRIPTION
This updates FSHOnline to use GoFSH 1.3.0. Some of the functions changed slightly and needed to be updated, and the boxes at the end of the output also needed to be edited to match what GoFSH now logs.