### PR TITLE
Replace Tab with Spaces

### DIFF
--- a/src/components/CodeMirrorComponent.js
+++ b/src/components/CodeMirrorComponent.js
@@ -297,6 +297,11 @@ export default function CodeMirrorComponent(props) {
           readOnly: props.isExamples,
           gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
           extraKeys: {
+            Tab: (cm) => {
+              // Replace tab character with two spaces
+              // Example described here: https://codemirror.net/doc/manual.html#keymaps
+              cm.replaceSelection('  ');
+            },
             'Ctrl-/': 'toggleComment',
             'Cmd-/': 'toggleComment',
             'Ctrl-Q': (cm) => {


### PR DESCRIPTION
This PR replaces "tabs" with spaces when you hit the tab key.

I noticed this recently and took a look while starting on the new syntax highlighting because I thought it would be something in the syntax/language mode, but it turns out you can set the setting directly on the editor. Technically, this adds the replacement for both the JSON editor and the FSH editor, but I was testing out the JSON editor, and it looks like when it auto-indents when you hit enter while typing some JSON, it inserts spaces, so I actually think this makes things more consistent there too.

In the FSH editor, if you type something like this:

```
Instance: Bob
InstanceOf: Patient
* name
  * given = "Bob"
```
and you hit tab to indent to the `* given  = "Bob"` line, two spaces will be inserted now. On the deployed version, a tab character is inserted, which causes an error when converting to JSON. There should be no errors when following the same steps on this branch.

Support for tabs has been mentioned recently, but since we haven't officially decided to implement it and it is a FSH specification issue and because this fix was simple, I added it separately.