### PR TITLE
Improve Comment Highlighting

### DIFF
--- a/src/components/CodeMirrorComponent.js
+++ b/src/components/CodeMirrorComponent.js
@@ -85,7 +85,13 @@ CodeMirror.defineSimpleMode('fsh', {
       regex: /'.*'/, // 'ucum'
       token: 'string'
     },
-    { regex: /\/\/.*/, token: 'comment' },
+    // The following two regex should be combined into: /(\s|^)\/\/.*/
+    // However, the ^ doesn't work as expected. See sol section: https://codemirror.net/demo/simplemode.html
+    // Instead, we break them into two separate cases:
+    // the comment is preceded by whitespace and the comment is at the start of a line.
+    { regex: /\s\/\/.*/, token: 'comment' },
+    { regex: /\/\/.*/, token: 'comment', sol: true },
+    // Start of multiline comment
     { regex: /\/\*/, token: 'comment', next: 'comment' }
   ],
   closingParen: [


### PR DESCRIPTION
This PR fixes [CIMPL-949](https://standardhealthrecord.atlassian.net/browse/CIMPL-949).

The issue that caused the incorrect syntax highlighting in FSH Online was actually not caused by URL matching. Instead, it was caused by too generous of comment matching. The example where I first noticed this actually wasn't matching on a URL, but on a code like `http://foo#bar`. Because it was missing the `.com`/`.org`/etc portion of the URL, it was not matching the URL regex, which is correct. However, the comment regex was too flexible and was matching on the `//` when it should not have been.

The VS Code extension only matches on comments that either start the line or are preceded by whitespace (seen [here](https://github.com/standardhealth/vscode-language-fsh/blob/master/syntaxes/fsh.tmLanguage.json#L123)). The CodeMirror component has problems using the `^` regex character, so instead, this behavior is broken out into two separate regular expressions in the `fsh` mode.

To test this:
- I believe [this](https://fshschool.org/FSHOnline/#/share/33ueh2O) is the example FSH that I first noticed the issue on, so make sure that works correctly now.
- This is some nonsense FSH, but I added a bunch of URLs and comments to it to check the syntax highlighting [here](https://fshschool.org/FSHOnline/#/share/3P6b4JM).
- Test out with other FSH to make sure I didn't miss a case or cause new problems.