### PR TITLE
Update GoFSH to v1.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3215,9 +3215,9 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "async": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "async-each": {
       "version": "1.0.3",
@@ -15466,9 +15466,9 @@
       }
     },
     "gofsh": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/gofsh/-/gofsh-1.6.0.tgz",
-      "integrity": "sha512-Q19bxw/sz5FDCnd3OWXvehGxtbwThKM2MjZNIU404LFDK7IkMv4cKsR3QA4m76i4RwJS9D0uUBZclyGxKRvnAA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/gofsh/-/gofsh-1.6.1.tgz",
+      "integrity": "sha512-7wH1b5THMZvdpgctOWQy/njJqHxyI2MJwPFaM3aKVVRouxhvID+7RRxVAUl6aWwu0WJ18zguM3KM7tjjVvEp4A==",
       "requires": {
         "antlr4": "~4.8.0",
         "chalk": "^4.1.0",
@@ -15478,7 +15478,7 @@
         "fhir": "^4.10.0",
         "flat": "^5.0.2",
         "fs-extra": "^9.0.1",
-        "fsh-sushi": "^2.5.0",
+        "fsh-sushi": "^2.6.0",
         "ini": "^1.3.8",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
@@ -18982,9 +18982,9 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "logform": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
-      "integrity": "sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.1.tgz",
+      "integrity": "sha512-7XB/tqc3VRbri9pRjU6E97mQ8vC27ivJ3lct4jhyT+n0JNDd4YKldFl0D75NqDp46hk8RC7Ma1Vjv/UPf67S+A==",
       "requires": {
         "@colors/colors": "1.5.0",
         "fecha": "^4.2.0",
@@ -23415,7 +23415,7 @@
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="
     },
     "stack-utils": {
       "version": "2.0.4",
@@ -24177,7 +24177,7 @@
     "toposort": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "tough-cookie": {
       "version": "4.0.0",
@@ -24213,7 +24213,7 @@
     "truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
       "requires": {
         "utf8-byte-length": "^1.0.1"
       }
@@ -24572,7 +24572,7 @@
     "utf8-byte-length": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
+      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
     },
     "util": {
       "version": "0.11.1",
@@ -25849,9 +25849,9 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "winston": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.7.2.tgz",
-      "integrity": "sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.1.tgz",
+      "integrity": "sha512-r+6YAiCR4uI3N8eQNOg8k3P3PqwAm20cLKlzVD9E66Ch39+LZC+VH1UKf9JemQj2B3QoUHfKD7Poewn0Pr3Y1w==",
       "requires": {
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "codemirror": "^5.62.3",
     "file-saver": "^2.0.5",
     "fsh-sushi": "^2.6.0",
-    "gofsh": "^1.6.0",
+    "gofsh": "^1.6.1",
     "jszip": "^3.7.1",
     "lodash": "^4.17.21",
     "null-loader": "^4.0.0",

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -59,7 +59,7 @@ export default function TopBar() {
                   FSH ONLINE
                 </Typography>
                 <Typography order={2} className={classes.versionText}>
-                  Powered by SUSHI v2.6.0 and GoFSH v1.6.0
+                  Powered by SUSHI v2.6.0 and GoFSH v1.6.1
                 </Typography>
               </StylesProvider>
             </Box>


### PR DESCRIPTION
This updates FSH Online to use the latest release of GoFSH. I tested this with [GoFSH #186](https://github.com/FHIR/GoFSH/issues/186) and confirmed that the latest version of GoFSH works in FSH Online and that the bug that is shown there and fixed in 1.6.1 is properly created in FSH Online.