### PR TITLE
Support FHIR R5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25865,6 +25865,12 @@
       "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
       "dev": true
     },
+    "node_modules/react-dev-utils/node_modules/react-error-overlay": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
+      "dev": true
+    },
     "node_modules/react-dev-utils/node_modules/strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -25902,12 +25908,6 @@
       "peerDependencies": {
         "react": "^16.14.0"
       }
-    },
-    "node_modules/react-error-overlay": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
-      "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
-      "dev": true
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -54297,7 +54297,7 @@
         "open": "^7.0.2",
         "pkg-up": "3.1.0",
         "prompts": "2.4.0",
-        "react-error-overlay": "^6.0.9",
+        "react-error-overlay": "6.0.9",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.7.2",
         "strip-ansi": "6.0.0",
@@ -54411,6 +54411,12 @@
           "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
           "dev": true
         },
+        "react-error-overlay": {
+          "version": "6.0.9",
+          "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+          "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
+          "dev": true
+        },
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -54441,12 +54447,6 @@
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
       }
-    },
-    "react-error-overlay": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
-      "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
-      "dev": true
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
     "react-app-rewired": "^2.1.6",
     "react-scripts": "^4.0.3"
   },
+  "overrides": {
+    "react-dev-utils": {
+      "react-error-overlay": "6.0.9"
+    }
+  },
   "scripts": {
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import FileSaver from 'file-saver';
 import JSZip from 'jszip';
 import { debounce, partition } from 'lodash';
 import clsx from 'clsx';
-import { createMuiTheme, makeStyles } from '@material-ui/core/styles';
+import { createTheme, makeStyles } from '@material-ui/core/styles';
 import { Grid, ThemeProvider } from '@material-ui/core';
 import { expandLink } from './utils/BitlyWorker';
 import TopBar from './components/TopBar';
@@ -75,7 +75,7 @@ const colors = {
   red: '#FD6668'
 };
 
-export const theme = createMuiTheme({
+export const theme = createTheme({
   palette: {
     success: {
       main: colors.blue,

--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -368,7 +368,7 @@ export default function FSHControls(props) {
             margin="dense"
             fullWidth
             label="Dependencies"
-            helperText="Format: packageId#version, packageId#version (e.g., hl7.fhir.us.core#5.0.1)"
+            helperText="Format: packageId#version, packageId#version (e.g., hl7.fhir.us.core#6.0.0)"
             defaultValue={dependencies}
             onChange={updateDependencyString}
           />

--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -173,14 +173,14 @@ export default function FSHControls(props) {
     props.resetLogMessages();
     props.onSUSHIClick(true, [''], true);
     setIsSUSHIRunning(true);
-    const dependencyArr = sliceDependency(dependencies);
+    const parsedDependencies = sliceDependency(dependencies);
     const config = {
       canonical: canonical ? canonical : 'http://example.org',
       version: version ? version : '1.0.0',
       FSHOnly: true,
       fhirVersion: fhirVersion ? [fhirVersion] : ['4.0.1']
     };
-    const outPackage = await runSUSHI(props.fshText, config, dependencyArr);
+    const outPackage = await runSUSHI(props.fshText, config, parsedDependencies);
     let jsonOutput = JSON.stringify(outPackage, replacer, 2);
     if (outPackage && outPackage.codeSystems) {
       if (

--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -362,6 +362,7 @@ export default function FSHControls(props) {
           >
             <MenuItem value={'4.0.1'}>4.0.1 (R4)</MenuItem>
             <MenuItem value={'4.3.0'}>4.3.0 (R4B)</MenuItem>
+            <MenuItem value={'5.0.0'}>5.0.0 (R5)</MenuItem>
           </TextField>
           <TextField
             id="dependencies"

--- a/src/tests/components/FSHControls.test.js
+++ b/src/tests/components/FSHControls.test.js
@@ -333,13 +333,13 @@ it('uses user provided dependencies when calling runSUSHI', async () => {
 
   const defaultConfig = { FSHOnly: true, canonical: 'http://example.org', fhirVersion: ['4.0.1'], version: '1.0.0' };
 
-  const expectedDependencyArr = [
-    ['hl7.fhir.us.core', '3.1.1'],
-    ['hello', '123']
+  const expectedDependencies = [
+    { packageId: 'hl7.fhir.us.core', version: '3.1.1' },
+    { packageId: 'hello', version: '123' }
   ];
 
   await waitFor(() => {
-    expect(runSUSHISpy).toHaveBeenCalledWith(undefined, defaultConfig, expectedDependencyArr); // Called with new dependencies
+    expect(runSUSHISpy).toHaveBeenCalledWith(undefined, defaultConfig, expectedDependencies); // Called with new dependencies
   });
 });
 

--- a/src/tests/utils/FSHHelpers.test.js
+++ b/src/tests/utils/FSHHelpers.test.js
@@ -15,7 +15,7 @@ const defaultConfig = {
 
 describe('#runSUSHI', () => {
   it('should return an undefined package when we get invalid FHIRDefinitions', async () => {
-    const dependencyArr = [];
+    const dependencies = [];
     const loadAndCleanDBSpy = jest
       .spyOn(processing, 'loadAndCleanDatabase')
       .mockReset()
@@ -25,7 +25,7 @@ describe('#runSUSHI', () => {
       });
     const text =
       'Profile: FishPatient Parent: Patient Id: fish-patient Title: "Fish Patient" Description: "A patient that is a type of fish."';
-    const outPackage = await runSUSHI(text, defaultConfig, dependencyArr);
+    const outPackage = await runSUSHI(text, defaultConfig, dependencies);
     expect(loadAndCleanDBSpy).toHaveBeenCalled();
     expect(outPackage).toBeUndefined();
   });

--- a/src/tests/utils/Load.test.js
+++ b/src/tests/utils/Load.test.js
@@ -1,4 +1,4 @@
-import { unzipDependencies, loadDependenciesInStorage, loadAsFHIRDefs } from '../../utils/Load';
+import { unzipDependencies, loadDependenciesInStorage, loadAsFHIRDefs, getLatestVersionNumber } from '../../utils/Load';
 import { fhirdefs } from 'fsh-sushi';
 import path from 'path';
 import nock from 'nock';
@@ -115,5 +115,34 @@ describe('#loadAsFHIRDefs', () => {
     expect(databaseReturn.allValueSets()).toHaveLength(1);
     expect(databaseReturn.allCodeSystems()).toHaveLength(1);
     expect(databaseReturn.allExtensions()).toHaveLength(0);
+  });
+});
+
+describe('#getLatestVersionNumber', () => {
+  it('should resolve with an id when latest tag is available', async () => {
+    nock('https://packages.fhir.org')
+      .get('/example.mock.package')
+      .reply(200, {
+        name: 'example.mock.package',
+        'dist-tags': {
+          latest: '1.0.0'
+        }
+      });
+    const latestVersion = await getLatestVersionNumber('example.mock.package');
+    expect(latestVersion).toEqual('1.0.0');
+  });
+
+  it('should reject when no latest tag is available', async () => {
+    nock('https://packages.fhir.org')
+      .get('/example.mock.without.version')
+      .reply(200, {
+        name: 'example.mock.without.version',
+        'dist-tags': {
+          // no latest
+          beta: '1.0.0-rc'
+        }
+      });
+    const latestVersion = getLatestVersionNumber('example.mock.without.version');
+    await expect(latestVersion).rejects.toEqual('no latest version found');
   });
 });

--- a/src/tests/utils/Load.test.js
+++ b/src/tests/utils/Load.test.js
@@ -128,7 +128,7 @@ describe('#getLatestVersionNumber', () => {
           latest: '1.0.0'
         }
       });
-    const latestVersion = await getLatestVersionNumber('example.mock.package');
+    const latestVersion = await getLatestVersionNumber({ packageId: 'example.mock.package', version: 'latest' });
     expect(latestVersion).toEqual('1.0.0');
   });
 
@@ -142,7 +142,7 @@ describe('#getLatestVersionNumber', () => {
           beta: '1.0.0-rc'
         }
       });
-    const latestVersion = getLatestVersionNumber('example.mock.without.version');
+    const latestVersion = getLatestVersionNumber({ packageId: 'example.mock.without.version', version: 'latest' });
     await expect(latestVersion).rejects.toEqual('no latest version found');
   });
 });

--- a/src/tests/utils/helpers.test.js
+++ b/src/tests/utils/helpers.test.js
@@ -5,8 +5,8 @@ describe('#sliceDependency()', () => {
     const input = 'hl7.fhir.us.core#3.1.1, , testing#123';
     const returnArr = sliceDependency(input);
     expect(returnArr).toEqual([
-      ['hl7.fhir.us.core', '3.1.1'],
-      ['testing', '123']
+      { packageId: 'hl7.fhir.us.core', version: '3.1.1' },
+      { packageId: 'testing', version: '123' }
     ]);
   });
 

--- a/src/utils/FSHHelpers.js
+++ b/src/utils/FSHHelpers.js
@@ -240,13 +240,13 @@ function addCoreFHIRVersionAndAutomaticDependencies(dependencies, coreFHIRVersio
     dependenciesToAdd.push(coreFHIRPackage);
   }
   const terminologyPkg = { packageId: 'hl7.terminology.r4', version: 'latest', isAutomatic: true };
-  const hasTerminology = hasDependency(dependencies, terminologyPkg);
+  const hasTerminology = hasDependency(dependencies, terminologyPkg, true);
   if (!hasTerminology) {
     dependenciesToAdd.push(terminologyPkg);
   }
   if (coreFHIRPackage.version.match(/^5\.0\.\d+$/)) {
     const extensionPkg = { packageId: 'hl7.fhir.uv.extensions', version: 'latest', isAutomatic: true };
-    const hasExtensions = hasDependency(dependencies, extensionPkg);
+    const hasExtensions = hasDependency(dependencies, extensionPkg, true);
     if (!hasExtensions) {
       dependenciesToAdd.push(extensionPkg);
     }
@@ -254,9 +254,10 @@ function addCoreFHIRVersionAndAutomaticDependencies(dependencies, coreFHIRVersio
   return dependenciesToAdd;
 }
 
-function hasDependency(dependenciesList, currentDependency) {
+function hasDependency(dependenciesList, currentDependency, ignoreVersion = false) {
   return dependenciesList.some(
-    (dep) => dep.packageId === currentDependency.packageId && dep.version === currentDependency.version
+    (dep) =>
+      dep.packageId === currentDependency.packageId && (ignoreVersion || dep.version === currentDependency.version)
   );
 }
 

--- a/src/utils/FSHHelpers.js
+++ b/src/utils/FSHHelpers.js
@@ -63,6 +63,14 @@ export async function runGoFSH(input, options) {
   if (!dependencies.some((d) => d === fhirVersionForDep)) {
     dependencies.push(fhirVersionForDep);
   }
+  if (!dependencies.some((d) => d === 'hl7.terminology.r4#latest')) {
+    dependencies.push('hl7.terminology.r4#latest');
+  }
+  if (coreFhirVersion.match(/^5\.0\.\d+$/)) {
+    if (!dependencies.some((d) => d === 'hl7.fhir.uv.extensions#latest')) {
+      dependencies.push('hl7.fhir.uv.extensions#latest');
+    }
+  }
   dependencies = sliceDependency(dependencies.join(','));
   defs = await loadAndCleanDatabase(defs, dependencies);
 

--- a/src/utils/Load.js
+++ b/src/utils/Load.js
@@ -99,7 +99,8 @@ export function loadAsFHIRDefs(FHIRdefs, database, dependency, id) {
 
 export function getLatestVersionNumber(dependency) {
   return new Promise((resolve, reject) => {
-    https.get(`https://packages.fhir.org/${dependency}`, function (res) {
+    const { packageId, isAutomatic } = dependency;
+    https.get(`https://packages.fhir.org/${packageId}`, function (res) {
       let body = '';
       res.on('data', function (chunk) {
         body += chunk;
@@ -109,7 +110,11 @@ export function getLatestVersionNumber(dependency) {
         if (parsedBody?.['dist-tags']?.latest?.length) {
           resolve(parsedBody['dist-tags'].latest);
         } else {
-          logger.error(`Could not determine latest released version of ${dependency}.`);
+          logger.error(
+            `Could not determine latest released version of ${
+              isAutomatic ? 'automatically-loaded dependency ' : ''
+            }${packageId}.`
+          );
           reject('no latest version found');
         }
       });

--- a/src/utils/Load.js
+++ b/src/utils/Load.js
@@ -96,3 +96,23 @@ export function loadAsFHIRDefs(FHIRdefs, database, dependency, id) {
     };
   });
 }
+
+export function getLatestVersionNumber(dependency) {
+  return new Promise((resolve, reject) => {
+    https.get(`https://packages.fhir.org/${dependency}`, function (res) {
+      let body = '';
+      res.on('data', function (chunk) {
+        body += chunk;
+      });
+      res.on('end', function () {
+        const parsedBody = JSON.parse(body);
+        if (parsedBody?.['dist-tags']?.latest?.length) {
+          resolve(parsedBody['dist-tags'].latest);
+        } else {
+          logger.error(`Could not determine latest released version of ${dependency}.`);
+          reject('no latest version found');
+        }
+      });
+    });
+  });
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,13 +1,13 @@
 export function sliceDependency(dependencies) {
-  let returnArr = [];
-  const arr = dependencies.split(',');
-  for (let i = 0; i < arr.length; i++) {
-    arr[i] = arr[i].trim();
-    if (arr[i] === '') {
-      continue;
-    }
-    let singleDep = arr[i].split('#');
-    returnArr.push([singleDep[0], singleDep[1]]);
-  }
-  return returnArr;
+  const dependenciesArray = dependencies.split(',');
+  return dependenciesArray
+    .map((dependency) => {
+      const trimmedDep = dependency.trim();
+      if (trimmedDep === '') {
+        return trimmedDep;
+      }
+      const [packageId, version] = trimmedDep.split('#');
+      return { packageId, version };
+    })
+    .filter((d) => d); // filter out any empty strings
 }


### PR DESCRIPTION
This PR adds support for FHIR R5 as a configurable FHIR version. In order to support this, a couple functions were added to properly detect what the `'latest'` version of a package is. This allows us to use the automatic dependencies required for R5, `hl7.terminology.r4#latest` and `hl7.fhir.uv.extensions#latest`.

Also, since `'latest'` is now supported, the `hl7.terminology.r4#latest` package is also loaded for any FHIR version, which mirrors SUSHI's behavior.

These packages are included when running both SUSHI and GoFSH. Right now, GoFSH does not add these automatic dependencies, but it will in the future.

I made three other small changes included here:

- Updated the example text to use the current published version of US Core in [36c7386](https://github.com/FSHSchool/FSHOnline/commit/36c738604f5e2b47e832025f64995c9512d5b800)
- There was a warning in the console about a change to Material UI, so [9dc2530](https://github.com/FSHSchool/FSHOnline/commit/9dc2530a4371da19f2d6ed842c2b6938186a6523) addresses that.
- There was an issue that was introduced by the PR that updated the package-lock because a transitive dependency was updated in a way that doesn't support the version of webpack we are currently using. This led to an error coming up every time the development server restarted (which is every time a file is saved), causing the app to freeze and needing a browser refresh. This isn't an issue on production since it is running from the build, not a development server that hot reloads. I added an override to fix the version to avoid this behavior in [b05f749](https://github.com/FSHSchool/FSHOnline/pull/134/commits/b05f74949c45f180be769b37f634c7c61d4bf960)