### PR TITLE
Add a link to the FSH Online Examples repo

### DIFF
--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -23,6 +23,7 @@ import {
   FormControlLabel,
   FormHelperText,
   Grid,
+  Link,
   MenuItem,
   Tooltip,
   TextField
@@ -89,6 +90,13 @@ const useStyles = makeStyles((theme) => ({
   dialogPaper: {
     maxHeight: '80vh',
     minHeight: '80vh'
+  },
+  dialogActions: {
+    justifyContent: 'space-between'
+  },
+  dialogActionsMessage: {
+    fontStyle: 'italic',
+    padding: '6px 8px'
   }
 }));
 
@@ -423,13 +431,19 @@ export default function FSHControls(props) {
             </Grid>
           </Grid>
         </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCopyToClipboard} color="primary">
-            <AssignmentOutlinedIcon></AssignmentOutlinedIcon> Copy to clipboard
-          </Button>
-          <Button onClick={handleCloseExamples} color="secondary">
-            Close
-          </Button>
+        <DialogActions className={classes.dialogActions}>
+          <div className={classes.dialogActionsMessage}>
+            Feel like an example is missing? Add to our collection of examples on{' '}
+            <Link href="https://github.com/FSHSchool/FSHOnline-Examples">GitHub</Link>!
+          </div>
+          <div>
+            <Button onClick={handleCopyToClipboard} color="primary">
+              <AssignmentOutlinedIcon></AssignmentOutlinedIcon> Copy to clipboard
+            </Button>
+            <Button onClick={handleCloseExamples} color="secondary">
+              Close
+            </Button>
+          </div>
         </DialogActions>
       </Dialog>
     </Box>

--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -96,7 +96,6 @@ const useStyles = makeStyles((theme) => ({
   },
   dialogActionsMessage: {
     fontStyle: 'italic',
-    fontSize: 'small',
     padding: '6px 8px'
   }
 }));
@@ -435,7 +434,7 @@ export default function FSHControls(props) {
         <DialogActions className={classes.dialogActions}>
           <div className={classes.dialogActionsMessage}>
             Feel like an example is missing? Add to our collection of examples on{' '}
-            <Link href="https://github.com/FSHSchool/FSHOnline-Examples">GitHub</Link>!
+            <Link href="https://github.com/FSHSchool/FSHOnline-Examples#readme">GitHub</Link>!
           </div>
           <div>
             <Button onClick={handleCopyToClipboard} color="primary">

--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -96,6 +96,7 @@ const useStyles = makeStyles((theme) => ({
   },
   dialogActionsMessage: {
     fontStyle: 'italic',
+    fontSize: 'small',
     padding: '6px 8px'
   }
 }));

--- a/src/components/FSHControls.js
+++ b/src/components/FSHControls.js
@@ -433,7 +433,7 @@ export default function FSHControls(props) {
         </DialogContent>
         <DialogActions className={classes.dialogActions}>
           <div className={classes.dialogActionsMessage}>
-            Feel like an example is missing? Add to our collection of examples on{' '}
+            Have an example that might be bene-fish-al? Seas the day and add to our collection on{' '}
             <Link href="https://github.com/FSHSchool/FSHOnline-Examples#readme">GitHub</Link>!
           </div>
           <div>

--- a/src/tests/components/FSHControls.test.js
+++ b/src/tests/components/FSHControls.test.js
@@ -464,7 +464,7 @@ it('should include a link to the examples repo', () => {
   expect(exampleRepoText).toBeInTheDocument();
   const exampleRepoUrl = getByRole('link');
   expect(exampleRepoUrl).toBeInTheDocument();
-  expect(exampleRepoUrl).toHaveAttribute('href', 'https://github.com/FSHSchool/FSHOnline-Examples');
+  expect(exampleRepoUrl).toHaveAttribute('href', 'https://github.com/FSHSchool/FSHOnline-Examples#readme');
 });
 
 it.skip('should populate editor when examples are collected', async () => {

--- a/src/tests/components/FSHControls.test.js
+++ b/src/tests/components/FSHControls.test.js
@@ -460,7 +460,7 @@ it('should include a link to the examples repo', () => {
   expect(examplesButton).toBeInTheDocument();
   fireEvent.click(examplesButton);
 
-  const exampleRepoText = getByText(/Feel like an example is missing?/);
+  const exampleRepoText = getByText(/Have an example that might be bene-fish-al?/);
   expect(exampleRepoText).toBeInTheDocument();
   const exampleRepoUrl = getByRole('link');
   expect(exampleRepoUrl).toBeInTheDocument();

--- a/src/tests/components/FSHControls.test.js
+++ b/src/tests/components/FSHControls.test.js
@@ -453,6 +453,20 @@ it('should properly render the examples in the file tree', async () => {
   expect(manifestChild2).toBeInTheDocument();
 });
 
+it('should include a link to the examples repo', () => {
+  const { getByRole, getByText } = render(<FSHControls exampleConfig={[]} />, container);
+
+  const examplesButton = getByRole('button', { name: /Examples/i });
+  expect(examplesButton).toBeInTheDocument();
+  fireEvent.click(examplesButton);
+
+  const exampleRepoText = getByText(/Feel like an example is missing?/);
+  expect(exampleRepoText).toBeInTheDocument();
+  const exampleRepoUrl = getByRole('link');
+  expect(exampleRepoUrl).toBeInTheDocument();
+  expect(exampleRepoUrl).toHaveAttribute('href', 'https://github.com/FSHSchool/FSHOnline-Examples');
+});
+
 it.skip('should populate editor when examples are collected', async () => {
   const updateTextValueSpy = jest.fn();
 


### PR DESCRIPTION
Add a short blurb with a link to the repo that holds the examples. Previously, this was only in the README file, but it would be useful to have it in the app itself.

Two small pieces to consider when reviewing this:

- Is the text too prominent? I could make it smaller and/or lighter, but I didn't want to get unnecessarily fancy. Let me know if you'd like screenshots of these options to consider. _**Edit**: I decided to make the font size "small" so now this question is better posed as - is it too small? not prominent enough?_
- How do you feel about the wording? It's a little joke-y, so I could definitely simplify it with something just like "View and add to the examples collection on Github".