### PR TITLE
Use separate SUSHI and GoFSH logger and stats

### DIFF
--- a/src/utils/FSHHelpers.js
+++ b/src/utils/FSHHelpers.js
@@ -3,12 +3,13 @@ import { fhirdefs, sushiExport, sushiImport, utils } from 'fsh-sushi';
 import { gofshExport, processor, utils as gofshUtils } from 'gofsh';
 import { fillTank, loadAndCleanDatabase } from './Processing';
 import { sliceDependency } from './helpers';
+import { fshOnlineLogger as logger, setCurrentLogger } from './logger';
 
 const FSHTank = sushiImport.FSHTank;
 const RawFSH = sushiImport.RawFSH;
 const exportFHIR = sushiExport.exportFHIR;
-const logger = utils.logger;
-const stats = utils.stats;
+const sushiStats = utils.stats;
+const gofshStats = gofshUtils.stats;
 const getRandomPun = utils.getRandomPun;
 const Type = utils.Type;
 const FHIRDefinitions = fhirdefs.FHIRDefinitions;
@@ -26,7 +27,8 @@ const FHIRDefinitions = fhirdefs.FHIRDefinitions;
  * @returns {string} the FSH
  */
 export async function runGoFSH(input, options) {
-  stats.reset();
+  gofshStats.reset();
+  setCurrentLogger('gofsh');
 
   // Read in the resources as strings
   const docs = [];
@@ -88,7 +90,8 @@ export async function runGoFSH(input, options) {
  * @returns Package with FHIR resources
  */
 export async function runSUSHI(input, config, dependencies = []) {
-  stats.reset();
+  sushiStats.reset();
+  setCurrentLogger('sushi');
 
   // Load dependencies
   let defs = new FHIRDefinitions();
@@ -148,8 +151,8 @@ export async function runSUSHI(input, config, dependencies = []) {
 }
 
 function printSUSHIResults(pkg) {
-  const numError = stats.numError;
-  const numWarn = stats.numWarn;
+  const numError = sushiStats.numError;
+  const numWarn = sushiStats.numWarn;
   // NOTE: These variables are creatively names to align well in the strings below while keeping prettier happy
   const profileNum = pad(pkg.profiles.length.toString(), 13);
   const extentNum = pad(pkg.extensions.length.toString(), 12);
@@ -197,9 +200,9 @@ function printGoFSHresults(pkg) {
   const instNum = pad(pkg.instances.length.toString(), 18);
   const invNum = pad(pkg.invariants.length.toString(), 17);
   const mapNum = pad(pkg.mappings.length.toString(), 18);
-  const errNumMsg = pad(`${stats.numError} Error${stats.numError !== 1 ? 's' : ''}`, 12);
-  const wrnNumMsg = padStart(`${stats.numWarn} Warning${stats.numWarn !== 1 ? 's' : ''}`, 12);
-  const aWittyMessageInvolvingABadFishPun = padEnd(getRandomPun(stats.numError, stats.numWarn), 37);
+  const errNumMsg = pad(`${gofshStats.numError} Error${gofshStats.numError !== 1 ? 's' : ''}`, 12);
+  const wrnNumMsg = padStart(`${gofshStats.numWarn} Warning${gofshStats.numWarn !== 1 ? 's' : ''}`, 12);
+  const aWittyMessageInvolvingABadFishPun = padEnd(getRandomPun(gofshStats.numError, gofshStats.numWarn), 37);
 
   // prettier-ignore
   const results = [

--- a/src/utils/Load.js
+++ b/src/utils/Load.js
@@ -1,8 +1,7 @@
 import tarStream from 'tar-stream';
 import zlib from 'zlib';
 import https from 'https';
-import { utils } from 'fsh-sushi';
-const logger = utils.logger;
+import { fshOnlineLogger as logger } from './logger';
 
 export function unzipDependencies(resources, dependency, id) {
   let returnPackage = { resourceArr: resources, emptyDependencies: [] };

--- a/src/utils/Processing.js
+++ b/src/utils/Processing.js
@@ -1,8 +1,8 @@
-import { fhirdefs, sushiImport, utils } from 'fsh-sushi';
-import { getLatestVersionNumber, loadAsFHIRDefs, loadDependenciesInStorage, unzipDependencies } from './Load';
 import { flatten } from 'lodash';
+import { fhirdefs, sushiImport } from 'fsh-sushi';
+import { getLatestVersionNumber, loadAsFHIRDefs, loadDependenciesInStorage, unzipDependencies } from './Load';
+import { fshOnlineLogger as logger } from './logger';
 
-const logger = utils.logger;
 const FHIRDefinitions = fhirdefs.FHIRDefinitions;
 const FSHTank = sushiImport.FSHTank;
 const importText = sushiImport.importText;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,14 @@
+import { utils as sushiUtils } from 'fsh-sushi';
+import { utils as gofshUtils } from 'gofsh';
+
+// Default the logger to SUSHI's logger, but support switching
+// between the loggers so that any file can import one logger
+// and have the stats tracked correctly
+export let fshOnlineLogger = sushiUtils.logger;
+export function setCurrentLogger(loggerName) {
+  if (loggerName === 'sushi') {
+    fshOnlineLogger = sushiUtils.logger;
+  } else if (loggerName === 'gofsh') {
+    fshOnlineLogger = gofshUtils.logger;
+  }
+}


### PR DESCRIPTION
This makes it so that FSH Online shows the correct number of errors and warnings in the summary box when running GoFSH. GoFSH previously hadn't had the correct number of errors and warnings for two reasons:

When FSH Online was logging any messages (this pretty much only happens in the `run` functions for SUSHI/GoFSH and when loading the FHIR definitions), it was only using the logger from SUSHI. This meant that if you encountered any of the errors logged within FSH Online itself when running GoFSH, it was not included in the "stats" at the bottom of the summary box. In order to fix this issue, I created a util export for a logger that FSH Online can use and a function that sets that logger. This lets the logger get reset when we start to run either GoFSH or SUSHI so that the correct logger is used for each tool. This also lets other files, like `Processing.js`, just import the logger once at the top and it will use the correct SUSHI or GoFSH logger, depending on which tool we are using.

The second change that was needed was using the correct `stats` when creating the summary boxes. Now that we're using separate loggers at the right times, we should be using the stats from each of those loggers. So use the GoFSH stats in the GoFSH box and the SUSHI stats in the SUSHI box.

To test this, you should create some FHIR JSON and run GoFSH and aim to get two types of errors/warnings: ones from GoFSH itself and directly from FSH Online. The stats in the summary should reflect how many errors/warnings you got from the run.

For example, how I tested this was with one JSON document that had a JSON error in it (this logs an error directly from FSH Online) and one JSON document with the following FSH in it (this logs a warning from GoFSH because `MyProfile` is not defined):

```json
{
  "resourceType": "Patient",
  "id": "MyExample",
  "meta": {
    "profile": [
      "http://example.org/StructureDefinition/MyProfile"
    ]
  }
}
```
This should log an error and a warning and have the correct total of both (with a correspondingly appropriate pun) in the summary box.