### PR TITLE
Update to the recommended 'defaults' value for browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,16 +56,7 @@
   "jest": {
     "resolver": "<rootDir>/resolver.js"
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+  "browserslist": [
+    "defaults"
+  ]
 }


### PR DESCRIPTION
Fixes #140 

This PR updates the `browserslist` in `package.json` to just specify the default values. This is what the [browserslists library documents as best practice](https://github.com/browserslist/browserslist#best-practices), so I think it makes sense for us to use this. I think this is changing how the code is built, which is why the error is not seen anymore. Using the default does exclude some old browsers, though, so if you don't think this is a sufficient solution, let me know.

To test this, build the app and serve the production build and test that the two examples convert FSH to FHIR successfully.