### PR TITLE
Add serve-build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ This will bundle the project in production mode and optimize the build for the b
 
 The build can be used to deploy the application. For more information, see the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) in the Create React App documentation.
 
+### Serve Build
+
+To serve the built application locally for testing, run the following command:
+
+```bash
+npm run serve-build
+```
+
+This will serve the built application from the `build` directory. It will be served on port 8000. You can access it at the following URL: [http://localhost:8000/FSHOnline/](http://localhost:8000/FSHOnline/).
+
 ### Eject
 
 **Note: this is a one-way operation. Once you `eject`, you can’t go back!**

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,14 +31,17 @@
         "tar-stream": "^2.1.3"
       },
       "devDependencies": {
+        "cors": "^2.8.5",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-prettier": "^3.1.3",
+        "express": "^4.18.2",
         "fake-indexeddb": "^3.1.1",
         "nock": "^13.2.2",
         "null-loader": "^4.0.1",
         "prettier": "^2.0.5",
         "react-app-rewired": "^2.1.6",
-        "react-scripts": "^4.0.3"
+        "react-scripts": "^4.0.3",
+        "serve-static": "^1.15.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6390,6 +6393,19 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -28876,6 +28892,16 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "cosmiconfig": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -27,14 +27,17 @@
     "tar-stream": "^2.1.3"
   },
   "devDependencies": {
+    "cors": "^2.8.5",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",
+    "express": "^4.18.2",
     "fake-indexeddb": "^3.1.1",
     "nock": "^13.2.2",
     "null-loader": "^4.0.1",
     "prettier": "^2.0.5",
     "react-app-rewired": "^2.1.6",
-    "react-scripts": "^4.0.3"
+    "react-scripts": "^4.0.3",
+    "serve-static": "^1.15.0"
   },
   "overrides": {
     "react-dev-utils": {
@@ -44,6 +47,7 @@
   "scripts": {
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
+    "serve-build": "node scripts/serve-build.js",
     "lint": "eslint \"./src/**/*.js\"",
     "lint-fix": "eslint \"./src/**/*.js\" --fix",
     "prettier": "prettier --check \"**/*.{js,ts}\"",

--- a/scripts/serve-build.js
+++ b/scripts/serve-build.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const serveStatic = require('serve-static');
+const cors = require('cors');
+const fs = require('fs');
+const path = require('path');
+
+const buildDir = path.resolve(__dirname, '../build');
+if (!fs.existsSync(buildDir)) {
+  console.error('No build dir detected. Run "npm run build" first.');
+  process.exit(1);
+}
+
+const app = express();
+app.use(cors());
+app.use('/FSHOnline', serveStatic(path.resolve(__dirname, '../build')));
+app.listen(8000, (err) => {
+  if (err != null) {
+    console.error(err);
+  }
+  console.log('NOTE: This is a development server intended to test static deployment ');
+  console.log('of FSH Online. This server is not intended for production use.');
+  console.log();
+  console.log(`Source directory: ${buildDir}`);
+  console.log('URL: http://localhost:8000/FSHOnline/');
+});


### PR DESCRIPTION
The serve-build script serves up the static build. This allows developers to more easily test the built application.

To test it, first run `npm run build` and then run `npm run serve-build`. After that, go to the URL printed to the console and try FSH Online.

Also try deleting the `build` folder and running `npm run serve-build`. You should get a helpful message.