### PR TITLE
Update display for resources without id or resourceType

### DIFF
--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -114,6 +114,18 @@ const checkFshType = (def) => {
   return null;
 };
 
+const checkIdToDisplay = (def) => {
+  if (def.id) {
+    return def.id;
+  }
+  if (def.resourceType) {
+    // Logical Models don't always have an id, so fall back to last part of the resourceType
+    return def.resourceType.substring(def.resourceType.lastIndexOf('/') + 1);
+  }
+  // If can't determine an id or a best guess from the resourceType, just return 'Untitled'
+  return 'Untitled';
+};
+
 // Flatten the package so we can render and navigate it more easily,
 // but keep high level attributes we'll need accessible
 const getIterablePackage = (defsPackage) => {
@@ -126,7 +138,11 @@ const getIterablePackage = (defsPackage) => {
     ...defsPackage.valueSets,
     ...defsPackage.codeSystems
   ];
-  return defArray.map((def) => ({ resourceType: checkFshType(def), id: def.id, def: JSON.stringify(def, null, 2) }));
+  return defArray.map((def) => ({
+    resourceType: checkFshType(def),
+    id: checkIdToDisplay(def),
+    def: JSON.stringify(def, null, 2)
+  }));
 };
 
 export default function JSONOutput(props) {
@@ -189,7 +205,7 @@ export default function JSONOutput(props) {
       if (!fhirDefinitions[currentDef]) {
         updatedDefs[currentDef] = {
           resourceType: checkFshType(latestJSON),
-          id: latestJSON.id ?? 'Untitled'
+          id: checkIdToDisplay(latestJSON)
         };
       }
 
@@ -200,7 +216,7 @@ export default function JSONOutput(props) {
 
       // Update id if it has changed or it is new
       if (!fhirDefinitions[currentDef] || latestJSON.id !== fhirDefinitions[currentDef].id) {
-        updatedDefs[currentDef].id = latestJSON.id ?? 'Untitled';
+        updatedDefs[currentDef].id = checkIdToDisplay(latestJSON);
       }
     } catch (e) {
       // Invalid JSON typed. Keep track of index.

--- a/src/components/JSONOutput.js
+++ b/src/components/JSONOutput.js
@@ -119,8 +119,10 @@ const checkIdToDisplay = (def) => {
     return def.id;
   }
   if (def.resourceType) {
-    // Logical Models don't always have an id, so fall back to last part of the resourceType
-    return def.resourceType.substring(def.resourceType.lastIndexOf('/') + 1);
+    // Logical Model instances don't always have an id, so fall back to last part of the resourceType
+    // All other definitions are StructureDefinitions/ValueSets/CodeSystems, which are guaranteed to have id
+    // so the only time this case is reached is through Logical Model Instances or someone typing/removing an id
+    return `Instance of ${def.resourceType.substring(def.resourceType.lastIndexOf('/') + 1)}`;
   }
   // If can't determine an id or a best guess from the resourceType, just return 'Untitled'
   return 'Untitled';

--- a/src/tests/components/JSONOutput.test.js
+++ b/src/tests/components/JSONOutput.test.js
@@ -394,9 +394,9 @@ describe('file tree display', () => {
       container
     );
 
-    const structureDef = getByText('StructureDefinition');
+    const structureDef = getByText('Instance of StructureDefinition');
     expect(structureDef).toBeInTheDocument();
-    const exampleLM = getByText('example-logical-model');
+    const exampleLM = getByText('Instance of example-logical-model');
     expect(exampleLM).toBeInTheDocument();
     const untitledDef = getByText('Untitled');
     expect(untitledDef).toBeInTheDocument();

--- a/src/tests/components/JSONOutput.test.js
+++ b/src/tests/components/JSONOutput.test.js
@@ -367,7 +367,13 @@ describe('file tree display', () => {
       profiles: [
         {
           resourceType: 'StructureDefinition'
-          // No id field - this is to represent the case when someone removed or never included an id. SUSHI packages should always have ids.
+          // No id field - this is to represent the case when someone removed or never included an id or a Logical Model without an id.
+        },
+        {
+          resourceType: 'http://example.org/StructureDefinition/example-logical-model'
+        },
+        {
+          other: 'not a resource type'
         }
       ],
       extensions: [],
@@ -388,6 +394,10 @@ describe('file tree display', () => {
       container
     );
 
+    const structureDef = getByText('StructureDefinition');
+    expect(structureDef).toBeInTheDocument();
+    const exampleLM = getByText('example-logical-model');
+    expect(exampleLM).toBeInTheDocument();
     const untitledDef = getByText('Untitled');
     expect(untitledDef).toBeInTheDocument();
   });


### PR DESCRIPTION
This PR improves handling for examples of Logical Models (or any JSON) that does not have an `id`. If there is no `id`, we try to calculate a related "display" to use in the sidebar on the right and on the top of the editor next to "FHIR JSON:". If there is no `id` or `resourceType`, then we'll fall back to the usual 'Untitled'.

To test this, you can try out using the new example of logical models that was recently contributed on this branch: [here](https://fshschool.org/FSHOnline/#/share/4botLUg).