### PR TITLE
Update automatically loaded dependencies

### DIFF
--- a/src/utils/FSHHelpers.js
+++ b/src/utils/FSHHelpers.js
@@ -242,16 +242,32 @@ function addCoreFHIRVersionAndAutomaticDependencies(dependencies, coreFHIRVersio
   if (!hasCoreFHIR) {
     dependenciesToAdd.push(coreFHIRPackage);
   }
-  const terminologyPkg = { packageId: 'hl7.terminology.r4', version: 'latest', isAutomatic: true };
-  const hasTerminology = hasDependency(dependencies, terminologyPkg, true);
-  if (!hasTerminology) {
-    dependenciesToAdd.push(terminologyPkg);
+  const toolsPkg = { packageId: 'hl7.fhir.uv.tools', version: 'latest', isAutomatic: true };
+  const hasTools = hasDependency(dependencies, toolsPkg, true);
+  if (!hasTools) {
+    dependenciesToAdd.push(toolsPkg);
   }
   if (coreFHIRPackage.version.match(/^5\.0\.\d+$/)) {
-    const extensionPkg = { packageId: 'hl7.fhir.uv.extensions', version: 'latest', isAutomatic: true };
+    const extensionPkg = { packageId: 'hl7.fhir.uv.extensions.r5', version: 'latest', isAutomatic: true };
     const hasExtensions = hasDependency(dependencies, extensionPkg, true);
+    const terminologyPkg = { packageId: 'hl7.terminology.r5', version: 'latest', isAutomatic: true };
+    const hasTerminology = hasDependency(dependencies, terminologyPkg, true);
     if (!hasExtensions) {
       dependenciesToAdd.push(extensionPkg);
+    }
+    if (!hasTerminology) {
+      dependenciesToAdd.push(terminologyPkg);
+    }
+  } else if (coreFHIRPackage.version.match(/^4\.0\.1$/) || coreFHIRPackage.version.match(/^4\.3\.\d+$/)) {
+    const extensionPkg = { packageId: 'hl7.fhir.uv.extensions.r4', version: 'latest', isAutomatic: true };
+    const hasExtensions = hasDependency(dependencies, extensionPkg, true);
+    const terminologyPkg = { packageId: 'hl7.terminology.r4', version: 'latest', isAutomatic: true };
+    const hasTerminology = hasDependency(dependencies, terminologyPkg, true);
+    if (!hasExtensions) {
+      dependenciesToAdd.push(extensionPkg);
+    }
+    if (!hasTerminology) {
+      dependenciesToAdd.push(terminologyPkg);
     }
   }
   return dependenciesToAdd;

--- a/src/utils/FSHHelpers.js
+++ b/src/utils/FSHHelpers.js
@@ -242,33 +242,28 @@ function addCoreFHIRVersionAndAutomaticDependencies(dependencies, coreFHIRVersio
   if (!hasCoreFHIR) {
     dependenciesToAdd.push(coreFHIRPackage);
   }
-  const toolsPkg = { packageId: 'hl7.fhir.uv.tools', version: 'latest', isAutomatic: true };
-  const hasTools = hasDependency(dependencies, toolsPkg, true);
-  if (!hasTools) {
-    dependenciesToAdd.push(toolsPkg);
-  }
+  AUTOMATIC_DEPENDENCIES.filter((dep) => dep.fhirVersions == null).forEach((dep) => {
+    const dependencyToAdd = { packageId: dep.packageId, version: dep.version, isAutomatic: true };
+    if (!hasDependency(dependencies, dependencyToAdd, true)) {
+      dependenciesToAdd.push(dependencyToAdd);
+    }
+  });
   if (coreFHIRPackage.version.match(/^5\.0\.\d+$/)) {
-    const extensionPkg = { packageId: 'hl7.fhir.uv.extensions.r5', version: 'latest', isAutomatic: true };
-    const hasExtensions = hasDependency(dependencies, extensionPkg, true);
-    const terminologyPkg = { packageId: 'hl7.terminology.r5', version: 'latest', isAutomatic: true };
-    const hasTerminology = hasDependency(dependencies, terminologyPkg, true);
-    if (!hasExtensions) {
-      dependenciesToAdd.push(extensionPkg);
-    }
-    if (!hasTerminology) {
-      dependenciesToAdd.push(terminologyPkg);
-    }
+    AUTOMATIC_DEPENDENCIES.filter((dep) => dep.fhirVersions?.includes('R5')).forEach((dep) => {
+      const dependencyToAdd = { packageId: dep.packageId, version: dep.version, isAutomatic: true };
+      if (!hasDependency(dependencies, dependencyToAdd, true)) {
+        dependenciesToAdd.push(dependencyToAdd);
+      }
+    });
   } else if (coreFHIRPackage.version.match(/^4\.0\.1$/) || coreFHIRPackage.version.match(/^4\.3\.\d+$/)) {
-    const extensionPkg = { packageId: 'hl7.fhir.uv.extensions.r4', version: 'latest', isAutomatic: true };
-    const hasExtensions = hasDependency(dependencies, extensionPkg, true);
-    const terminologyPkg = { packageId: 'hl7.terminology.r4', version: 'latest', isAutomatic: true };
-    const hasTerminology = hasDependency(dependencies, terminologyPkg, true);
-    if (!hasExtensions) {
-      dependenciesToAdd.push(extensionPkg);
-    }
-    if (!hasTerminology) {
-      dependenciesToAdd.push(terminologyPkg);
-    }
+    AUTOMATIC_DEPENDENCIES.filter(
+      (dep) => dep.fhirVersions?.includes('R4') || dep.fhirVersions?.includes('R4B')
+    ).forEach((dep) => {
+      const dependencyToAdd = { packageId: dep.packageId, version: dep.version, isAutomatic: true };
+      if (!hasDependency(dependencies, dependencyToAdd, true)) {
+        dependenciesToAdd.push(dependencyToAdd);
+      }
+    });
   }
   return dependenciesToAdd;
 }
@@ -291,3 +286,30 @@ export function getCoreFHIRPackageIdentifier(fhirVersion) {
     return `hl7.fhir.r4.core`;
   }
 }
+
+const AUTOMATIC_DEPENDENCIES = [
+  {
+    packageId: 'hl7.fhir.uv.tools',
+    version: 'latest'
+  },
+  {
+    packageId: 'hl7.terminology.r4',
+    version: 'latest',
+    fhirVersions: ['R4', 'R4B']
+  },
+  {
+    packageId: 'hl7.terminology.r5',
+    version: 'latest',
+    fhirVersions: ['R5']
+  },
+  {
+    packageId: 'hl7.fhir.uv.extensions.r4',
+    version: 'latest',
+    fhirVersions: ['R4', 'R4B']
+  },
+  {
+    packageId: 'hl7.fhir.uv.extensions.r5',
+    version: 'latest',
+    fhirVersions: ['R5']
+  }
+];

--- a/src/utils/FSHHelpers.js
+++ b/src/utils/FSHHelpers.js
@@ -242,29 +242,14 @@ function addCoreFHIRVersionAndAutomaticDependencies(dependencies, coreFHIRVersio
   if (!hasCoreFHIR) {
     dependenciesToAdd.push(coreFHIRPackage);
   }
-  AUTOMATIC_DEPENDENCIES.filter((dep) => dep.fhirVersions == null).forEach((dep) => {
+  AUTOMATIC_DEPENDENCIES.filter(
+    (dep) => dep.fhirVersions == null || dep.fhirVersions.some((v) => coreFHIRPackage.version.startsWith(v))
+  ).forEach((dep) => {
     const dependencyToAdd = { packageId: dep.packageId, version: dep.version, isAutomatic: true };
     if (!hasDependency(dependencies, dependencyToAdd, true)) {
       dependenciesToAdd.push(dependencyToAdd);
     }
   });
-  if (coreFHIRPackage.version.match(/^5\.0\.\d+$/)) {
-    AUTOMATIC_DEPENDENCIES.filter((dep) => dep.fhirVersions?.includes('R5')).forEach((dep) => {
-      const dependencyToAdd = { packageId: dep.packageId, version: dep.version, isAutomatic: true };
-      if (!hasDependency(dependencies, dependencyToAdd, true)) {
-        dependenciesToAdd.push(dependencyToAdd);
-      }
-    });
-  } else if (coreFHIRPackage.version.match(/^4\.0\.1$/) || coreFHIRPackage.version.match(/^4\.3\.\d+$/)) {
-    AUTOMATIC_DEPENDENCIES.filter(
-      (dep) => dep.fhirVersions?.includes('R4') || dep.fhirVersions?.includes('R4B')
-    ).forEach((dep) => {
-      const dependencyToAdd = { packageId: dep.packageId, version: dep.version, isAutomatic: true };
-      if (!hasDependency(dependencies, dependencyToAdd, true)) {
-        dependenciesToAdd.push(dependencyToAdd);
-      }
-    });
-  }
   return dependenciesToAdd;
 }
 
@@ -295,21 +280,21 @@ const AUTOMATIC_DEPENDENCIES = [
   {
     packageId: 'hl7.terminology.r4',
     version: 'latest',
-    fhirVersions: ['R4', 'R4B']
+    fhirVersions: ['4.0', '4.3']
   },
   {
     packageId: 'hl7.terminology.r5',
     version: 'latest',
-    fhirVersions: ['R5']
+    fhirVersions: ['5.0']
   },
   {
     packageId: 'hl7.fhir.uv.extensions.r4',
     version: 'latest',
-    fhirVersions: ['R4', 'R4B']
+    fhirVersions: ['4.0', '4.3']
   },
   {
     packageId: 'hl7.fhir.uv.extensions.r5',
     version: 'latest',
-    fhirVersions: ['R5']
+    fhirVersions: ['5.0']
   }
 ];


### PR DESCRIPTION
This PR updates FSH Online to automatically load dependencies that are more in line with SUSHI's current implementation. We use the `latest` version of `hl7.fhir.uv.tools` (rather than `current`, like SUSHI) because FSH Online does not support `current` versions at the moment. The `hl7.terminology` and `hl7.fhir.uv.extensions` packages are now loaded based on the current FHIR version being used, similar to SUSHI.

I made a small refactor to the code in the second commit because it seemed simpler.

You can test this by changing to the different FHIR versions FSH Online supports and ensuring that the proper packages are loaded for each one.