### PR TITLE
Add variations on start and build scripts for Windows systems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       },
       "devDependencies": {
         "cors": "^2.8.5",
+        "cross-env": "^7.0.3",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-prettier": "^3.1.3",
         "express": "^4.18.2",
@@ -6464,6 +6465,24 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -28894,6 +28913,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   },
   "scripts": {
     "start": "NODE_OPTIONS=--openssl-legacy-provider react-app-rewired start",
+    "start:win": "set NODE_OPTIONS=--openssl-legacy-provider && react-app-rewired start",
     "build": "NODE_OPTIONS=--openssl-legacy-provider react-app-rewired build",
+    "build:win": "set NODE_OPTIONS=--openssl-legacy-provider && react-app-rewired build",
     "serve-build": "node scripts/serve-build.js",
     "lint": "eslint \"./src/**/*.js\"",
     "lint-fix": "eslint \"./src/**/*.js\" --fix",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "cors": "^2.8.5",
+    "cross-env": "^7.0.3",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",
     "express": "^4.18.2",
@@ -50,10 +51,8 @@
     }
   },
   "scripts": {
-    "start": "NODE_OPTIONS=--openssl-legacy-provider react-app-rewired start",
-    "start:win": "set NODE_OPTIONS=--openssl-legacy-provider && react-app-rewired start",
-    "build": "NODE_OPTIONS=--openssl-legacy-provider react-app-rewired build",
-    "build:win": "set NODE_OPTIONS=--openssl-legacy-provider && react-app-rewired build",
+    "start": "cross-env NODE_OPTIONS=--openssl-legacy-provider react-app-rewired start",
+    "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider react-app-rewired build",
     "serve-build": "node scripts/serve-build.js",
     "lint": "eslint \"./src/**/*.js\"",
     "lint-fix": "eslint \"./src/**/*.js\" --fix",


### PR DESCRIPTION
These scripts set an environment variable before invoking react-app-rewired. The syntax for doing this is different on Windows systems. Two new scripts are defined to make these actions available to Windows users.