### PR TITLE
Update to SUSHI 3.9.0 and GoFSH 2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "browserify-zlib": "^0.2.0",
         "codemirror": "^5.65.16",
         "file-saver": "^2.0.5",
-        "fsh-sushi": "^3.8.0",
-        "gofsh": "^2.3.0",
+        "fsh-sushi": "^3.9.0",
+        "gofsh": "^2.3.1",
         "jszip": "^3.10.1",
         "lodash": "^4.17.21",
         "react": "^16.13.1",
@@ -9439,82 +9439,80 @@
       }
     },
     "node_modules/fhir-package-loader": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.5.0.tgz",
-      "integrity": "sha512-Q+W+l0jNLkpC2lUCIbtJ76P7xUvU3Bady/dcHo6f45q/CpFtvE9DyfeSNIGJZwpI72IIVZe5lvZ+lA58CGoVuA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-1.0.0.tgz",
+      "integrity": "sha512-x3VY3RY1wkJv8Fd7dA7fY3aw+6Vg7qeCU0pci7wUaEhnJ84k7Lnca6dfH00l36uzH1N5EwVX51iKuuwsS6RdlA==",
       "dependencies": {
-        "axios": "^0.21.1",
+        "axios": "^1.6.7",
         "chalk": "^4.1.2",
-        "commander": "^8.3.0",
-        "fs-extra": "^10.0.0",
-        "https-proxy-agent": "^5.0.0",
+        "commander": "^11.1.0",
+        "fs-extra": "^11.2.0",
+        "https-proxy-agent": "^7.0.2",
         "lodash": "^4.17.21",
         "semver": "^7.5.4",
-        "tar": "^5.0.11",
+        "tar": "^6.2.0",
         "temp": "^0.9.1",
-        "winston": "^3.3.3"
+        "winston": "^3.11.0"
       },
       "bin": {
         "fpl": "dist/app.js"
       }
     },
-    "node_modules/fhir-package-loader/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    "node_modules/fhir-package-loader/node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/fhir-package-loader/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "engines": {
-        "node": ">= 12"
+        "node": ">=16"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fhir-package-loader/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
-    "node_modules/fhir-package-loader/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+    "node_modules/fhir-package-loader/node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/fhir-package-loader/node_modules/tar": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.11.tgz",
-      "integrity": "sha512-E6q48d5y4XSCD+Xmwc0yc8lXuyDK38E0FB8N4S/drQRtXOMUhfhDxbB0xr2KKDhNfO51CFmoa6Oz00nAkWsjnA==",
-      "dependencies": {
-        "chownr": "^1.1.4",
-        "fs-minipass": "^2.1.0",
-        "minipass": "^3.1.3",
-        "minizlib": "^2.1.2",
-        "mkdirp": "^0.5.5",
-        "yallist": "^4.0.0"
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 6"
       }
-    },
-    "node_modules/fhir-package-loader/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/fhir/node_modules/inherits": {
       "version": "2.0.3",
@@ -10137,9 +10135,9 @@
       }
     },
     "node_modules/fsh-sushi": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.8.0.tgz",
-      "integrity": "sha512-YvmG7Jqvcnlrcrvi7GvO6wMiYyGdC/qFUKYYuHT6VrrnS3Cke3b13xG6xARXSI6Iuw2QJlMTs/fYpUb5oHMnww==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.9.0.tgz",
+      "integrity": "sha512-T4Bj/lPNC82KFRcom5m5kL9k2jcYDLIaFUmkyYQSeTVjbVsK4DyK8OpoZvsgzGrON1CSRseiCtt/giCyLQBLGA==",
       "dependencies": {
         "ajv": "^8.12.0",
         "antlr4": "4.13.1-patch-1",
@@ -10199,26 +10197,6 @@
       "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/fsh-sushi/node_modules/fhir-package-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-1.0.0.tgz",
-      "integrity": "sha512-x3VY3RY1wkJv8Fd7dA7fY3aw+6Vg7qeCU0pci7wUaEhnJ84k7Lnca6dfH00l36uzH1N5EwVX51iKuuwsS6RdlA==",
-      "dependencies": {
-        "axios": "^1.6.7",
-        "chalk": "^4.1.2",
-        "commander": "^11.1.0",
-        "fs-extra": "^11.2.0",
-        "https-proxy-agent": "^7.0.2",
-        "lodash": "^4.17.21",
-        "semver": "^7.5.4",
-        "tar": "^6.2.0",
-        "temp": "^0.9.1",
-        "winston": "^3.11.0"
-      },
-      "bin": {
-        "fpl": "dist/app.js"
       }
     },
     "node_modules/fsh-sushi/node_modules/form-data": {
@@ -10532,20 +10510,20 @@
       }
     },
     "node_modules/gofsh": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/gofsh/-/gofsh-2.3.0.tgz",
-      "integrity": "sha512-5Ppk6NG2ebRy2zJ/5M4p4aOyfx7NCpXCImaz1gz/3SWTXHnzWpLWdsjDdZbCFwEVeyWBLxQhR07JNyqMLUGaLQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/gofsh/-/gofsh-2.3.1.tgz",
+      "integrity": "sha512-MLYMbMMhyJeS1BurQSoLHyAC1Sg/zgP6MqHWW+DZVn68/FBpo7PN6VlTQgoUn/7g1qtOfEtQ/nsqujKbOL1YKQ==",
       "dependencies": {
-        "antlr4": "~4.8.0",
+        "antlr4": "~4.13.1-patch-1",
         "chalk": "^4.1.0",
         "commander": "^6.0.0",
         "diff": "^5.0.0",
         "diff2html": "^3.1.18",
         "fhir": "^4.10.0",
-        "fhir-package-loader": "^0.5.0",
+        "fhir-package-loader": "^1.0.0",
         "flat": "^5.0.2",
         "fs-extra": "^9.0.1",
-        "fsh-sushi": "^3.6.1",
+        "fsh-sushi": "^3.9.0",
         "ini": "^1.3.8",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
@@ -11247,6 +11225,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -31259,67 +31238,65 @@
       }
     },
     "fhir-package-loader": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.5.0.tgz",
-      "integrity": "sha512-Q+W+l0jNLkpC2lUCIbtJ76P7xUvU3Bady/dcHo6f45q/CpFtvE9DyfeSNIGJZwpI72IIVZe5lvZ+lA58CGoVuA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-1.0.0.tgz",
+      "integrity": "sha512-x3VY3RY1wkJv8Fd7dA7fY3aw+6Vg7qeCU0pci7wUaEhnJ84k7Lnca6dfH00l36uzH1N5EwVX51iKuuwsS6RdlA==",
       "requires": {
-        "axios": "^0.21.1",
+        "axios": "^1.6.7",
         "chalk": "^4.1.2",
-        "commander": "^8.3.0",
-        "fs-extra": "^10.0.0",
-        "https-proxy-agent": "^5.0.0",
+        "commander": "^11.1.0",
+        "fs-extra": "^11.2.0",
+        "https-proxy-agent": "5.0.0",
         "lodash": "^4.17.21",
         "semver": "^7.5.4",
-        "tar": "^5.0.11",
+        "tar": "^6.2.0",
         "temp": "^0.9.1",
-        "winston": "^3.3.3"
+        "winston": "^3.11.0"
       },
       "dependencies": {
-        "chownr": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+        "axios": {
+          "version": "1.6.8",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+          "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+          "requires": {
+            "follow-redirects": "^1.15.6",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
         },
         "commander": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+          "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
         },
         "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
         },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
           "requires": {
-            "minimist": "^1.2.6"
+            "agent-base": "6",
+            "debug": "4"
           }
-        },
-        "tar": {
-          "version": "5.0.11",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.11.tgz",
-          "integrity": "sha512-E6q48d5y4XSCD+Xmwc0yc8lXuyDK38E0FB8N4S/drQRtXOMUhfhDxbB0xr2KKDhNfO51CFmoa6Oz00nAkWsjnA==",
-          "requires": {
-            "chownr": "^1.1.4",
-            "fs-minipass": "^2.1.0",
-            "minipass": "^3.1.3",
-            "minizlib": "^2.1.2",
-            "mkdirp": "^0.5.5",
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -31768,9 +31745,9 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.8.0.tgz",
-      "integrity": "sha512-YvmG7Jqvcnlrcrvi7GvO6wMiYyGdC/qFUKYYuHT6VrrnS3Cke3b13xG6xARXSI6Iuw2QJlMTs/fYpUb5oHMnww==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.9.0.tgz",
+      "integrity": "sha512-T4Bj/lPNC82KFRcom5m5kL9k2jcYDLIaFUmkyYQSeTVjbVsK4DyK8OpoZvsgzGrON1CSRseiCtt/giCyLQBLGA==",
       "requires": {
         "ajv": "^8.12.0",
         "antlr4": "4.13.1-patch-1",
@@ -31821,23 +31798,6 @@
           "version": "11.1.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
           "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="
-        },
-        "fhir-package-loader": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-1.0.0.tgz",
-          "integrity": "sha512-x3VY3RY1wkJv8Fd7dA7fY3aw+6Vg7qeCU0pci7wUaEhnJ84k7Lnca6dfH00l36uzH1N5EwVX51iKuuwsS6RdlA==",
-          "requires": {
-            "axios": "^1.6.7",
-            "chalk": "^4.1.2",
-            "commander": "^11.1.0",
-            "fs-extra": "^11.2.0",
-            "https-proxy-agent": "5.0.0",
-            "lodash": "^4.17.21",
-            "semver": "^7.5.4",
-            "tar": "^6.2.0",
-            "temp": "^0.9.1",
-            "winston": "^3.11.0"
-          }
         },
         "form-data": {
           "version": "4.0.0",
@@ -32070,9 +32030,9 @@
       }
     },
     "gofsh": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/gofsh/-/gofsh-2.3.0.tgz",
-      "integrity": "sha512-5Ppk6NG2ebRy2zJ/5M4p4aOyfx7NCpXCImaz1gz/3SWTXHnzWpLWdsjDdZbCFwEVeyWBLxQhR07JNyqMLUGaLQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/gofsh/-/gofsh-2.3.1.tgz",
+      "integrity": "sha512-MLYMbMMhyJeS1BurQSoLHyAC1Sg/zgP6MqHWW+DZVn68/FBpo7PN6VlTQgoUn/7g1qtOfEtQ/nsqujKbOL1YKQ==",
       "requires": {
         "antlr4": "4.13.1-patch-1",
         "chalk": "^4.1.0",
@@ -32080,10 +32040,10 @@
         "diff": "^5.0.0",
         "diff2html": "^3.1.18",
         "fhir": "^4.10.0",
-        "fhir-package-loader": "^0.5.0",
+        "fhir-package-loader": "^1.0.0",
         "flat": "^5.0.2",
         "fs-extra": "^9.0.1",
-        "fsh-sushi": "^3.6.1",
+        "fsh-sushi": "^3.9.0",
         "ini": "^1.3.8",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
@@ -32649,6 +32609,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "browserify-zlib": "^0.2.0",
     "codemirror": "^5.65.16",
     "file-saver": "^2.0.5",
-    "fsh-sushi": "^3.8.0",
-    "gofsh": "^2.3.0",
+    "fsh-sushi": "^3.9.0",
+    "gofsh": "^2.3.1",
     "jszip": "^3.10.1",
     "lodash": "^4.17.21",
     "react": "^16.13.1",
@@ -45,6 +45,9 @@
     "fsh-sushi": {
       "https-proxy-agent": "5.0.0",
       "ini": "4.0.0"
+    },
+    "gofsh": {
+      "https-proxy-agent": "5.0.0"
     },
     "react-dev-utils": {
       "react-error-overlay": "6.0.9"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       "https-proxy-agent": "5.0.0",
       "ini": "4.0.0"
     },
-    "gofsh": {
+    "fhir-package-loader": {
       "https-proxy-agent": "5.0.0"
     },
     "react-dev-utils": {

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -59,7 +59,7 @@ export default function TopBar() {
                   FSH ONLINE
                 </Typography>
                 <Typography order={2} className={classes.versionText}>
-                  Powered by SUSHI v3.8.0 and GoFSH v2.3.0
+                  Powered by SUSHI v3.9.0 and GoFSH v2.3.1
                 </Typography>
               </StylesProvider>
             </Box>


### PR DESCRIPTION
Updates to the latest SUSHI and GoFSH versions.

I tested out new features from both, and everything worked as expected. I did have to add the same override we needed for SUSHI now that we're using a newer GoFSH.