### PR TITLE
Fix Example URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "lint-fix": "eslint \"./src/**/*.{js,jsx}\" --fix",
     "prettier": "prettier --check \"**/*.{js,ts,jsx,tsx}\"",
     "prettier-fix": "prettier --write \"**/*.{js,ts,jsx,tsx}\"",
-    "test": "vitest"
+    "test": "vitest",
+    "check": "vitest --run && npm run lint && npm run prettier"
   },
   "browserslist": [
     "defaults"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,7 +62,7 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const githubURL = 'https://raw.githubusercontent.com/FSHSchool/FSHOnline-Examples/main/';
+const githubURL = 'https://raw.githubusercontent.com/FSHSchool/FSHOnline-Examples/main';
 const defaultInfoMessage = 'There are no messages to display in the console.';
 const defaultProblemMessage = 'There are no problems to display in the console.';
 let infoMessages = [defaultInfoMessage];
@@ -87,7 +87,7 @@ console.log = function getMessages(message) {
   infoMessages.push(message);
 };
 
-/* 
+/*
 Parses metadata into a separate object and converts the manifest into a form that can
 be consumed by the TreeView component
 */


### PR DESCRIPTION
**Description:** This PR fixes a bug that was causing examples with spaces in their path (e.g., `Code Systems`, `Rule Sets`, and `Value Sets` examples) to load as `404: Not Found`. The issue was that the constructed example URLs had a double-slash (`//`) where a single slash (`/`) should be -- which caused GitHub to issue an HTTP 301 redirect, but in doing so, it re-encoded the `%` in `%20`, resulting in an invalid URL.

I've also added a script to enable `npm run check` for consistency with other FSH repos.

**Testing Instructions:** Run FSH Online and confirm that you can load examples in `Code Systems`, `Rule Sets`, and `Value Sets`. Run `npm run check` and confirm it runs the tests, lint, and prettier.

**Related Issue:** N/A
